### PR TITLE
fix: session persistence survives extension reload (#54)

### DIFF
--- a/.ai-team/decisions/inbox/copilot-directive-brand-taglines.md
+++ b/.ai-team/decisions/inbox/copilot-directive-brand-taglines.md
@@ -1,0 +1,10 @@
+### 2026-02-15: EditLess brand taglines and tone
+**By:** Casey Irvine (via Copilot)
+**What:** Approved taglines for docs, marketing, and README:
+- "Leave the editor for your mind."
+- "Microsoft Teams is the IDE of the future."
+- "Give yourself a promotion, manage your teams of AI agents."
+- "Join the editorless software development revolution."
+- "Edit less, effortless."
+Previously captured (from team.md): "Plan, delegate, and review your AI team's work."
+**Why:** User request — establishing the voice and tone for EditLess branding and documentation.

--- a/.ai-team/decisions/inbox/copilot-directive-handy-dictation.md
+++ b/.ai-team/decisions/inbox/copilot-directive-handy-dictation.md
@@ -1,0 +1,4 @@
+### 2026-02-15: Dictation input — expect Handy transcription artifacts
+**By:** Casey Irvine (via Copilot)
+**What:** Casey dictates using Handy, which sometimes produces repeated words or misspellings. Don't second-guess — ask if something is unclear.
+**Why:** User request — captured for team memory

--- a/.ai-team/decisions/inbox/copilot-directive-multi-repo-philosophy.md
+++ b/.ai-team/decisions/inbox/copilot-directive-multi-repo-philosophy.md
@@ -1,0 +1,4 @@
+### 2026-02-15: Multi-repo workflow philosophy — don't open repos, open a workspace
+**By:** Casey Irvine (via Copilot)
+**What:** The EditLess philosophy is: don't open VS Code in a repo. Open it in a central folder and work across multiple repos simultaneously. Think in terms of working with agents, not in terms of an editor tied to one repo. This should be a core part of the documentation and philosophy sections.
+**Why:** User directive — this is a fundamental EditLess workflow pattern that changes how people think about their dev environment.

--- a/.ai-team/decisions/inbox/copilot-directive-rapid-change.md
+++ b/.ai-team/decisions/inbox/copilot-directive-rapid-change.md
@@ -1,0 +1,4 @@
+### 2026-02-15: Acknowledge rapid tooling evolution in docs
+**By:** Casey Irvine (via Copilot)
+**What:** Documentation should acknowledge that AI dev tools are changing rapidly and EditLess may need to evolve quickly. Be honest with users that this space moves fast.
+**Why:** User request — sets expectations and builds trust with users.

--- a/.ai-team/decisions/inbox/copilot-directive-recommend-squad.md
+++ b/.ai-team/decisions/inbox/copilot-directive-recommend-squad.md
@@ -1,0 +1,4 @@
+### 2026-02-15: Recommend Squad as the starting point for new vibe coders
+**By:** Casey Irvine (via Copilot)
+**What:** Documentation should recommend Squad as the entry point for people new to vibe coding or feeling overwhelmed by the agent landscape. Squad makes it easy and fun. This goes in the recommendations/philosophy docs — if you're new, start with Squad.
+**Why:** User directive — many people reaching out are intimidated by the agent landscape. Squad lowers the barrier.


### PR DESCRIPTION
Closes #54

Three bugs in `reconcile()` caused sessions to vanish on Developer Window reload:

1. **Timing race:** `vscode.window.terminals` is empty during early activation. `reconcile()` matched zero terminals then `_persist()` overwrote saved data with an empty array — permanently deleting session history.
2. **No retry:** Added `onDidOpenTerminal` listener so terminals that appear after initial activation are still matched.
3. **Data preservation:** `_persist()` now keeps unmatched saved entries instead of dropping them.

Tests: 144 passing