### PR TITLE
fix: add getParent to tree provider — fixes reveal crash (#95)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,11 @@ export function activate(context: vscode.ExtensionContext): void {
       if (!info) return;
       const matchingItem = treeProvider.findTerminalItem(terminal);
       if (matchingItem) {
-        treeView.reveal(matchingItem, { select: true, focus: false });
+        try {
+          treeView.reveal(matchingItem, { select: true, focus: false });
+        } catch {
+          // reveal() may fail if tree is not visible or item is stale
+        }
       }
     }),
   );


### PR DESCRIPTION
Closes #95

P0 — VS Code extension host crashes when switching terminals because TreeDataProvider.reveal() requires getParent().

## Changes
- Added parent property to EditlessTreeItem
- Set parent references when building child items in getSquadChildren() and getCategoryChildren()
- Implemented getParent() on EditlessTreeProvider
- Fixed findTerminalItem() to build parent references for reveal() traversal
- Added defensive try/catch around reveal() call in extension.ts
- Added 3 tests for getParent traversal (root, squad children, category children)

Working as Morty (Extension Dev)