### PR TITLE
test: P1 coverage — upgrader, status bar, watcher, PRs tree, github-client

### DIFF
--- a/src/__tests__/github-client.test.ts
+++ b/src/__tests__/github-client.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: () => mockExecFileAsync,
+}));
+
+import { isGhAvailable, fetchAssignedIssues, fetchMyPRs, fetchLinkedPRs } from '../github-client';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isGhAvailable
+// ---------------------------------------------------------------------------
+
+describe('isGhAvailable', () => {
+  it('should return true when gh auth status succeeds', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    expect(await isGhAvailable()).toBe(true);
+  });
+
+  it('should return false when gh auth status fails', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('not logged in'));
+    expect(await isGhAvailable()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchAssignedIssues
+// ---------------------------------------------------------------------------
+
+describe('fetchAssignedIssues', () => {
+  it('should parse valid JSON output', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 42,
+        title: 'Fix bug',
+        state: 'OPEN',
+        url: 'https://github.com/owner/repo/issues/42',
+        labels: [{ name: 'bug' }],
+        assignees: [{ login: 'user1' }],
+        milestone: { title: 'v1.0' },
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const issues = await fetchAssignedIssues('owner/repo');
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].number).toBe(42);
+    expect(issues[0].title).toBe('Fix bug');
+    expect(issues[0].labels).toEqual(['bug']);
+    expect(issues[0].assignees).toEqual(['user1']);
+    expect(issues[0].milestone).toBe('v1.0');
+    expect(issues[0].repository).toBe('owner/repo');
+  });
+
+  it('should return empty array on failure', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('gh not found'));
+    expect(await fetchAssignedIssues('owner/repo')).toEqual([]);
+  });
+
+  it('should return empty array on empty JSON array', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '[]', stderr: '' });
+    expect(await fetchAssignedIssues('owner/repo')).toEqual([]);
+  });
+
+  it('should handle null milestone', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 1,
+        title: 'No milestone',
+        state: 'OPEN',
+        url: 'u',
+        labels: [],
+        assignees: [],
+        milestone: null,
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const issues = await fetchAssignedIssues('owner/repo');
+    expect(issues[0].milestone).toBe('');
+  });
+
+  it('should return empty array on malformed JSON', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: 'not json{{{', stderr: '' });
+    expect(await fetchAssignedIssues('owner/repo')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchMyPRs
+// ---------------------------------------------------------------------------
+
+describe('fetchMyPRs', () => {
+  it('should parse valid PR output', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 10,
+        title: 'Add feature',
+        state: 'OPEN',
+        isDraft: false,
+        url: 'https://github.com/owner/repo/pull/10',
+        headRefName: 'feat-branch',
+        baseRefName: 'main',
+        reviewDecision: 'APPROVED',
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const prs = await fetchMyPRs('owner/repo');
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(10);
+    expect(prs[0].headRef).toBe('feat-branch');
+    expect(prs[0].baseRef).toBe('main');
+    expect(prs[0].reviewDecision).toBe('APPROVED');
+    expect(prs[0].repository).toBe('owner/repo');
+  });
+
+  it('should return empty array on failure', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('fail'));
+    expect(await fetchMyPRs('owner/repo')).toEqual([]);
+  });
+
+  it('should return empty array on empty JSON', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '[]', stderr: '' });
+    expect(await fetchMyPRs('owner/repo')).toEqual([]);
+  });
+
+  it('should handle null reviewDecision', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 5,
+        title: 'Draft PR',
+        state: 'OPEN',
+        isDraft: true,
+        url: 'u',
+        headRefName: 'draft',
+        baseRefName: 'main',
+        reviewDecision: null,
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const prs = await fetchMyPRs('owner/repo');
+    expect(prs[0].reviewDecision).toBe('');
+  });
+
+  it('should return empty array on malformed JSON', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '}{bad', stderr: '' });
+    expect(await fetchMyPRs('owner/repo')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLinkedPRs
+// ---------------------------------------------------------------------------
+
+describe('fetchLinkedPRs', () => {
+  it('should search by issue number', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 20,
+        title: 'Linked PR',
+        state: 'OPEN',
+        isDraft: false,
+        url: 'u',
+        headRefName: 'fix',
+        baseRefName: 'main',
+        reviewDecision: 'APPROVED',
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const prs = await fetchLinkedPRs('owner/repo', 99);
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(20);
+    expect(mockExecFileAsync).toHaveBeenCalledWith('gh', expect.arrayContaining(['99']));
+  });
+
+  it('should return empty array on failure', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('fail'));
+    expect(await fetchLinkedPRs('owner/repo', 1)).toEqual([]);
+  });
+
+  it('should return empty array on empty JSON', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '[]', stderr: '' });
+    expect(await fetchLinkedPRs('owner/repo', 1)).toEqual([]);
+  });
+
+  it('should handle null reviewDecision in linked PRs', async () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 30,
+        title: 'PR',
+        state: 'MERGED',
+        isDraft: false,
+        url: 'u',
+        headRefName: 'h',
+        baseRefName: 'b',
+        reviewDecision: null,
+      },
+    ]);
+    mockExecFileAsync.mockResolvedValue({ stdout: ghOutput, stderr: '' });
+
+    const prs = await fetchLinkedPRs('owner/repo', 5);
+    expect(prs[0].reviewDecision).toBe('');
+  });
+});

--- a/src/__tests__/prs-tree.test.ts
+++ b/src/__tests__/prs-tree.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockIsGhAvailable = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+const mockFetchMyPRs = vi.fn().mockResolvedValue([]);
+
+vi.mock('vscode', () => {
+  const TreeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 };
+
+  class TreeItem {
+    label: string;
+    collapsibleState: number;
+    iconPath?: unknown;
+    description?: string;
+    contextValue?: string;
+    tooltip?: unknown;
+    command?: unknown;
+    id?: string;
+    pr?: unknown;
+    constructor(label: string, collapsibleState: number = TreeItemCollapsibleState.None) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  }
+
+  class ThemeIcon {
+    id: string;
+    constructor(id: string) { this.id = id; }
+  }
+
+  class MarkdownString {
+    value: string;
+    constructor(value: string) { this.value = value; }
+  }
+
+  class EventEmitter {
+    private listeners: Function[] = [];
+    get event() {
+      return (listener: Function) => {
+        this.listeners.push(listener);
+        return { dispose: () => { this.listeners = this.listeners.filter(l => l !== listener); } };
+      };
+    }
+    fire(value?: unknown) { this.listeners.forEach(l => l(value)); }
+    dispose() { this.listeners = []; }
+  }
+
+  return {
+    TreeItem, TreeItemCollapsibleState, ThemeIcon, MarkdownString, EventEmitter,
+    Uri: { parse: (s: string) => ({ toString: () => s }) },
+  };
+});
+
+vi.mock('../github-client', () => ({
+  isGhAvailable: (...args: unknown[]) => mockIsGhAvailable(...(args as [])),
+  fetchMyPRs: (...args: unknown[]) => mockFetchMyPRs(...(args as [string])),
+}));
+
+import { PRsTreeProvider, PRsTreeItem } from '../prs-tree';
+import type { GitHubPR } from '../github-client';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsGhAvailable.mockResolvedValue(false);
+  mockFetchMyPRs.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePR(overrides: Partial<GitHubPR> = {}): GitHubPR {
+  return {
+    number: 1,
+    title: 'Test PR',
+    state: 'OPEN',
+    isDraft: false,
+    url: 'https://github.com/owner/repo/pull/1',
+    headRef: 'feature',
+    baseRef: 'main',
+    repository: 'owner/repo',
+    reviewDecision: '',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// derivePRState — all 6 states
+// ---------------------------------------------------------------------------
+
+describe('PRsTreeProvider — derivePRState', () => {
+  async function getPRItemState(pr: GitHubPR): Promise<string> {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchMyPRs.mockResolvedValue([pr]);
+
+    const provider = new PRsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    const children = provider.getChildren();
+    expect(children).toHaveLength(1);
+    return (children[0].description as string).split(' · ')[0];
+  }
+
+  it('should derive "draft" state', async () => {
+    expect(await getPRItemState(makePR({ isDraft: true }))).toBe('draft');
+  });
+
+  it('should derive "merged" state', async () => {
+    expect(await getPRItemState(makePR({ state: 'MERGED' }))).toBe('merged');
+  });
+
+  it('should derive "closed" state', async () => {
+    expect(await getPRItemState(makePR({ state: 'CLOSED' }))).toBe('closed');
+  });
+
+  it('should derive "approved" state', async () => {
+    expect(await getPRItemState(makePR({ reviewDecision: 'APPROVED' }))).toBe('approved');
+  });
+
+  it('should derive "changes-requested" state', async () => {
+    expect(await getPRItemState(makePR({ reviewDecision: 'CHANGES_REQUESTED' }))).toBe('changes-requested');
+  });
+
+  it('should derive "open" when reviewDecision is empty (default)', async () => {
+    expect(await getPRItemState(makePR({ reviewDecision: '' }))).toBe('open');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-repo grouping
+// ---------------------------------------------------------------------------
+
+describe('PRsTreeProvider — multi-repo grouping', () => {
+  it('should show flat PR list for single repo', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchMyPRs.mockResolvedValue([makePR({ number: 1 }), makePR({ number: 2, title: 'Second' })]);
+
+    const provider = new PRsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    const children = provider.getChildren();
+    expect(children).toHaveLength(2);
+    expect(children[0].contextValue).toBe('pull-request');
+  });
+
+  it('should show repo headers for multiple repos', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchMyPRs.mockImplementation(async (repo: string) => {
+      if (repo === 'owner/repo-a') return [makePR({ number: 1, repository: 'owner/repo-a' })];
+      if (repo === 'owner/repo-b') return [makePR({ number: 2, repository: 'owner/repo-b' })];
+      return [];
+    });
+
+    const provider = new PRsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo-a', 'owner/repo-b']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    const roots = provider.getChildren();
+    expect(roots).toHaveLength(2);
+    expect(roots[0].contextValue).toBe('repo-group');
+    expect(roots[0].label).toBe('owner/repo-a');
+    expect(roots[1].label).toBe('owner/repo-b');
+
+    // Children of repo header are PRs
+    const repoAPRs = provider.getChildren(roots[0]);
+    expect(repoAPRs).toHaveLength(1);
+    expect(repoAPRs[0].contextValue).toBe('pull-request');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading and empty states
+// ---------------------------------------------------------------------------
+
+describe('PRsTreeProvider — loading & empty states', () => {
+  it('should show loading item while fetching', () => {
+    mockIsGhAvailable.mockReturnValue(new Promise(() => {})); // Never resolves
+    const provider = new PRsTreeProvider();
+    provider.setRepos(['owner/repo']);
+
+    // Fetch starts, sets _loading = true, fires tree data changed
+    // We read children immediately while loading
+    const children = provider.getChildren();
+    // First fire happens right away with loading true
+    expect(children.some(c => c.label === 'Loading...')).toBe(true);
+  });
+
+  it('should show "No open PRs" when gh available but no PRs', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchMyPRs.mockResolvedValue([]);
+
+    const provider = new PRsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    const children = provider.getChildren();
+    expect(children).toHaveLength(1);
+    expect(children[0].label).toBe('No open PRs');
+  });
+
+  it('should show config placeholder when no repos set', () => {
+    const provider = new PRsTreeProvider();
+    const children = provider.getChildren();
+    expect(children).toHaveLength(1);
+    expect(children[0].label).toBe('Configure GitHub repos in settings');
+  });
+});

--- a/src/__tests__/squad-upgrader.test.ts
+++ b/src/__tests__/squad-upgrader.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockExecAsync, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: () => mockExecAsync,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    showQuickPick: vi.fn(),
+    withProgress: vi.fn(),
+    createStatusBarItem: vi.fn(),
+  },
+  env: { openExternal: vi.fn() },
+  Uri: { parse: (s: string) => s },
+  ProgressLocation: { Notification: 15 },
+  commands: { registerCommand: vi.fn() },
+}));
+
+import { checkNpxAvailable, isSquadInitialized, getLocalSquadVersion } from '../squad-upgrader';
+import * as path from 'path';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// checkNpxAvailable
+// ---------------------------------------------------------------------------
+
+describe('checkNpxAvailable', () => {
+  it('should return true when npx --version succeeds', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: '10.0.0', stderr: '' });
+    expect(await checkNpxAvailable()).toBe(true);
+  });
+
+  it('should return false when npx --version throws', async () => {
+    mockExecAsync.mockRejectedValue(new Error('not found'));
+    expect(await checkNpxAvailable()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSquadInitialized
+// ---------------------------------------------------------------------------
+
+describe('isSquadInitialized', () => {
+  it('should return true when .ai-team directory exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(isSquadInitialized('/some/path')).toBe(true);
+    expect(mockExistsSync).toHaveBeenCalledWith(path.join('/some/path', '.ai-team'));
+  });
+
+  it('should return false when .ai-team directory does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(isSquadInitialized('/some/path')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLocalSquadVersion
+// ---------------------------------------------------------------------------
+
+describe('getLocalSquadVersion', () => {
+  const squadPath = '/my/squad';
+  const agentFile = path.join(squadPath, '.github', 'agents', 'squad.agent.md');
+
+  it('should parse version from frontmatter', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      '---\nversion: 1.2.3\ntitle: Squad\n---\n# Content',
+    );
+    expect(getLocalSquadVersion(squadPath)).toBe('1.2.3');
+    expect(mockReadFileSync).toHaveBeenCalledWith(agentFile, 'utf-8');
+  });
+
+  it('should return null when agent file does not exist', () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === agentFile) return false;
+      return true;
+    });
+    expect(getLocalSquadVersion(squadPath)).toBeNull();
+  });
+
+  it('should return null when file has no frontmatter', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('# No frontmatter here');
+    expect(getLocalSquadVersion(squadPath)).toBeNull();
+  });
+
+  it('should return null when frontmatter has no version field', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('---\ntitle: Squad\nauthor: Test\n---\n# Content');
+    expect(getLocalSquadVersion(squadPath)).toBeNull();
+  });
+
+  it('should return null when readFileSync throws', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => { throw new Error('EACCES'); });
+    expect(getLocalSquadVersion(squadPath)).toBeNull();
+  });
+
+  it('should trim whitespace from version string', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('---\nversion:   2.0.0-beta  \n---\n');
+    expect(getLocalSquadVersion(squadPath)).toBe('2.0.0-beta');
+  });
+});

--- a/src/__tests__/status-bar.test.ts
+++ b/src/__tests__/status-bar.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockShow, mockDispose, mockScanSquad } = vi.hoisted(() => ({
+  mockShow: vi.fn(),
+  mockDispose: vi.fn(),
+  mockScanSquad: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  window: {
+    createStatusBarItem: vi.fn(() => ({
+      text: '',
+      command: undefined as string | undefined,
+      tooltip: undefined as string | undefined,
+      show: mockShow,
+      dispose: mockDispose,
+    })),
+  },
+  StatusBarAlignment: { Left: 1, Right: 2 },
+}));
+
+vi.mock('../scanner', () => ({
+  scanSquad: mockScanSquad,
+}));
+
+import { EditlessStatusBar } from '../status-bar';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSquad(id: string) {
+  return { id, name: `Squad ${id}`, path: `/path/${id}`, icon: '🤖', universe: 'test' };
+}
+
+function makeRegistry(squads: ReturnType<typeof makeSquad>[]) {
+  return { loadSquads: vi.fn(() => squads) } as any;
+}
+
+function makeTerminalManager(count: number) {
+  return { getAllTerminals: vi.fn(() => Array(count).fill({ terminal: {} })) } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockScanSquad.mockReturnValue({ inboxCount: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// update()
+// ---------------------------------------------------------------------------
+
+describe('EditlessStatusBar — update()', () => {
+  it('should scan squads and render agent/session counts', () => {
+    const squads = [makeSquad('a'), makeSquad('b')];
+    const bar = new EditlessStatusBar(makeRegistry(squads), makeTerminalManager(3));
+
+    bar.update();
+
+    expect(mockScanSquad).toHaveBeenCalledTimes(2);
+    expect(mockShow).toHaveBeenCalled();
+  });
+
+  it('should show inbox badge when inbox count > 0', () => {
+    const squads = [makeSquad('a')];
+    mockScanSquad.mockReturnValue({ inboxCount: 5 });
+    const bar = new EditlessStatusBar(makeRegistry(squads), makeTerminalManager(1));
+
+    bar.update();
+
+    // Access the status bar item through the mock
+    const item = (bar as any)._item;
+    expect(item.text).toContain('📥 5');
+  });
+
+  it('should not show inbox badge when inbox count is 0', () => {
+    const squads = [makeSquad('a')];
+    mockScanSquad.mockReturnValue({ inboxCount: 0 });
+    const bar = new EditlessStatusBar(makeRegistry(squads), makeTerminalManager(1));
+
+    bar.update();
+
+    const item = (bar as any)._item;
+    expect(item.text).not.toContain('📥');
+  });
+
+  it('should handle zero squads', () => {
+    const bar = new EditlessStatusBar(makeRegistry([]), makeTerminalManager(0));
+
+    bar.update();
+
+    const item = (bar as any)._item;
+    expect(item.text).toContain('0 agents');
+    expect(item.text).toContain('0 sessions');
+    expect(mockShow).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSessionsOnly()
+// ---------------------------------------------------------------------------
+
+describe('EditlessStatusBar — updateSessionsOnly()', () => {
+  it('should use cached inbox count instead of rescanning', () => {
+    const squads = [makeSquad('a')];
+    mockScanSquad.mockReturnValue({ inboxCount: 3 });
+    const bar = new EditlessStatusBar(makeRegistry(squads), makeTerminalManager(1));
+
+    bar.update();
+    mockScanSquad.mockClear();
+
+    bar.updateSessionsOnly();
+
+    expect(mockScanSquad).not.toHaveBeenCalled();
+    const item = (bar as any)._item;
+    expect(item.text).toContain('📥 3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispose()
+// ---------------------------------------------------------------------------
+
+describe('EditlessStatusBar — dispose()', () => {
+  it('should dispose the status bar item', () => {
+    const bar = new EditlessStatusBar(makeRegistry([]), makeTerminalManager(0));
+    bar.dispose();
+    expect(mockDispose).toHaveBeenCalledOnce();
+  });
+
+  it('should tolerate being disposed twice', () => {
+    const bar = new EditlessStatusBar(makeRegistry([]), makeTerminalManager(0));
+    bar.dispose();
+    // Second dispose — if the underlying mock throws, the test fails
+    bar.dispose();
+    expect(mockDispose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/watcher.test.ts
+++ b/src/__tests__/watcher.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockCreateFSWatcher, mockGetConfiguration } = vi.hoisted(() => ({
+  mockCreateFSWatcher: vi.fn(),
+  mockGetConfiguration: vi.fn(),
+}));
+
+vi.mock('vscode', () => {
+  class RelativePattern {
+    base: unknown;
+    pattern: string;
+    constructor(base: unknown, pattern: string) {
+      this.base = base;
+      this.pattern = pattern;
+    }
+  }
+  return {
+    RelativePattern,
+    Uri: { file: (p: string) => ({ fsPath: p }) },
+    workspace: {
+      createFileSystemWatcher: mockCreateFSWatcher,
+      getConfiguration: mockGetConfiguration,
+    },
+  };
+});
+
+import { SquadWatcher } from '../watcher';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSquad(id: string) {
+  return { id, name: id, path: `/path/${id}`, icon: '🤖', universe: 'test' };
+}
+
+function makeFakeWatcher() {
+  const handlers: Record<string, Function> = {};
+  return {
+    onDidChange: vi.fn((h: Function) => { handlers.change = h; }),
+    onDidCreate: vi.fn((h: Function) => { handlers.create = h; }),
+    onDidDelete: vi.fn((h: Function) => { handlers.delete = h; }),
+    dispose: vi.fn(),
+    _fire(event: 'change' | 'create' | 'delete') { handlers[event]?.(); },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  mockGetConfiguration.mockReturnValue({ get: (_k: string, def: number) => def });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+describe('SquadWatcher — constructor', () => {
+  it('should create one file system watcher per squad', () => {
+    const w1 = makeFakeWatcher();
+    const w2 = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValueOnce(w1).mockReturnValueOnce(w2);
+
+    const _watcher = new SquadWatcher([makeSquad('a'), makeSquad('b')], vi.fn());
+
+    expect(mockCreateFSWatcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle empty squads array', () => {
+    const _watcher = new SquadWatcher([], vi.fn());
+    expect(mockCreateFSWatcher).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSquads()
+// ---------------------------------------------------------------------------
+
+describe('SquadWatcher — updateSquads()', () => {
+  it('should dispose old watchers and create new ones', () => {
+    const oldWatcher = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValueOnce(oldWatcher);
+
+    const watcher = new SquadWatcher([makeSquad('a')], vi.fn());
+    expect(mockCreateFSWatcher).toHaveBeenCalledTimes(1);
+
+    const newWatcher = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValueOnce(newWatcher);
+
+    watcher.updateSquads([makeSquad('b')]);
+
+    expect(oldWatcher.dispose).toHaveBeenCalled();
+    expect(mockCreateFSWatcher).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Debounce behavior
+// ---------------------------------------------------------------------------
+
+describe('SquadWatcher — debounce', () => {
+  it('should debounce rapid changes into one notification', () => {
+    const fakeW = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValue(fakeW);
+    const callback = vi.fn();
+
+    const _watcher = new SquadWatcher([makeSquad('a')], callback);
+
+    // Fire 5 rapid change events
+    fakeW._fire('change');
+    fakeW._fire('change');
+    fakeW._fire('change');
+    fakeW._fire('create');
+    fakeW._fire('delete');
+
+    // Before debounce elapses — nothing yet
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('a');
+  });
+
+  it('should use configured debounce time', () => {
+    mockGetConfiguration.mockReturnValue({ get: (_k: string, _def: number) => 200 });
+    const fakeW = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValue(fakeW);
+    const callback = vi.fn();
+
+    const _watcher = new SquadWatcher([makeSquad('a')], callback);
+    fakeW._fire('change');
+
+    vi.advanceTimersByTime(199);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispose()
+// ---------------------------------------------------------------------------
+
+describe('SquadWatcher — dispose()', () => {
+  it('should dispose all watchers and clear timers', () => {
+    const fakeW = makeFakeWatcher();
+    mockCreateFSWatcher.mockReturnValue(fakeW);
+    const callback = vi.fn();
+
+    const watcher = new SquadWatcher([makeSquad('a')], callback);
+
+    // Trigger a change to create a pending timer
+    fakeW._fire('change');
+
+    watcher.dispose();
+
+    expect(fakeW.dispose).toHaveBeenCalled();
+
+    // Timer should have been cleared — advancing time should NOT fire callback
+    vi.advanceTimersByTime(1000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should handle dispose with no squads', () => {
+    const watcher = new SquadWatcher([], vi.fn());
+    expect(() => watcher.dispose()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #111, closes #113, closes #115, closes #118, closes #120

## What
Five new test files covering untested P1 modules:

- **squad-upgrader.test.ts** (10 tests) — checkNpxAvailable, isSquadInitialized, getLocalSquadVersion with edge cases
- **status-bar.test.ts** (7 tests) — update(), updateSessionsOnly(), dispose()
- **watcher.test.ts** (7 tests) — constructor, updateSquads, debounce, dispose
- **prs-tree.test.ts** (11 tests) — derivePRState (6 states), multi-repo grouping, loading/empty states
- **github-client.test.ts** (16 tests) — isGhAvailable, fetchAssignedIssues, fetchMyPRs, fetchLinkedPRs

**Total: 51 new tests (308 total, up from 257)**

Working as Meeseeks (Tester)