### PR TITLE
feat: hide terminal on squad add (#127)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -694,8 +694,8 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
       const terminal = vscode.window.createTerminal({
         name: `Squad ${action}: ${path.basename(dirPath)}`,
         cwd: dirPath,
+        hideFromUser: true,
       });
-      terminal.show();
       terminal.sendText(command);
 
       vscode.window.showInformationMessage(


### PR DESCRIPTION
Closes #127

Terminals created when adding a squad now use `hideFromUser: true` so they don't steal focus from the Agents panel. Manually launched terminals are unaffected.

## Changes
- `extension.ts`: Added `hideFromUser: true` to `createTerminal` options in `editless.addSquad` command
- Removed `terminal.show()` call — hidden terminals don't need it