### PR TITLE
feat: deep-link configure buttons to settings (#102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
         "category": "EditLess"
       },
       {
+        "command": "editless.configureAdo",
+        "title": "Configure Azure DevOps",
+        "category": "EditLess"
+      },
+      {
         "command": "editless.openInBrowser",
         "title": "Open in Browser",
         "category": "EditLess",
@@ -288,6 +293,7 @@
         { "command": "editless.openFilePreview", "when": "false" },
         { "command": "editless.goToPR", "when": "false" },
         { "command": "editless.configureRepos", "when": "false" },
+        { "command": "editless.configureAdo", "when": "false" },
         { "command": "editless.addNew", "when": "false" },
         { "command": "editless.relaunchSession", "when": "false" },
         { "command": "editless.dismissOrphan", "when": "false" }
@@ -422,6 +428,22 @@
               "items": { "type": "string" }
             }
           }
+        },
+        "editless.ado.organization": {
+          "type": "string",
+          "default": "",
+          "description": "Azure DevOps organization URL (e.g., https://dev.azure.com/myorg)",
+          "markdownDescription": "Azure DevOps organization URL for the **Work Items** and **Pull Requests** panes.\n\nExample: `\"https://dev.azure.com/myorg\"`",
+          "scope": "resource",
+          "order": 32
+        },
+        "editless.ado.project": {
+          "type": "string",
+          "default": "",
+          "description": "Azure DevOps project name",
+          "markdownDescription": "Azure DevOps project to show in the **Work Items** and **Pull Requests** panes.",
+          "scope": "resource",
+          "order": 33
         },
         "editless.agentCreationCommand": {
           "type": "string",

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -967,11 +967,23 @@ describe('extension command handlers', () => {
   // --- editless.configureRepos ----------------------------------------------
 
   describe('editless.configureRepos', () => {
-    it('should open settings for editless.github.repos', async () => {
+    it('should open settings for editless.github', async () => {
       await getHandler('editless.configureRepos')();
       expect(mockExecuteCommand).toHaveBeenCalledWith(
         'workbench.action.openSettings',
-        'editless.github.repos',
+        'editless.github',
+      );
+    });
+  });
+
+  // --- editless.configureAdo -------------------------------------------------
+
+  describe('editless.configureAdo', () => {
+    it('should open settings for editless.ado', async () => {
+      await getHandler('editless.configureAdo')();
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        'workbench.action.openSettings',
+        'editless.ado',
       );
     });
   });

--- a/src/__tests__/prs-tree.test.ts
+++ b/src/__tests__/prs-tree.test.ts
@@ -214,7 +214,8 @@ describe('PRsTreeProvider — loading & empty states', () => {
   it('should show config placeholder when no repos set', () => {
     const provider = new PRsTreeProvider();
     const children = provider.getChildren();
-    expect(children).toHaveLength(1);
-    expect(children[0].label).toBe('Configure GitHub repos in settings');
+    expect(children).toHaveLength(2);
+    expect(children[0].label).toBe('Configure in GitHub');
+    expect(children[1].label).toBe('Configure in ADO');
   });
 });

--- a/src/__tests__/tree-providers.test.ts
+++ b/src/__tests__/tree-providers.test.ts
@@ -110,9 +110,11 @@ describe('WorkItemsTreeProvider', () => {
     const provider = new WorkItemsTreeProvider();
     const children = provider.getChildren();
 
-    expect(children).toHaveLength(1);
-    expect(children[0].label).toBe('Configure GitHub repos in settings');
+    expect(children).toHaveLength(2);
+    expect(children[0].label).toBe('Configure in GitHub');
+    expect(children[1].label).toBe('Configure in ADO');
     expect(children[0].iconPath).toBeDefined();
+    expect(children[1].iconPath).toBeDefined();
   });
 
   it('should return empty array when getChildren is called with an unrecognised element', async () => {
@@ -240,9 +242,11 @@ describe('PRsTreeProvider', () => {
     const provider = new PRsTreeProvider();
     const children = provider.getChildren();
 
-    expect(children).toHaveLength(1);
-    expect(children[0].label).toBe('Configure GitHub repos in settings');
+    expect(children).toHaveLength(2);
+    expect(children[0].label).toBe('Configure in GitHub');
+    expect(children[1].label).toBe('Configure in ADO');
     expect(children[0].iconPath).toBeDefined();
+    expect(children[1].iconPath).toBeDefined();
   });
 
   it('should return empty array when getChildren is called with an unrecognised element', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -470,7 +470,14 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   // Configure GitHub repos (opens settings)
   context.subscriptions.push(
     vscode.commands.registerCommand('editless.configureRepos', async () => {
-      await vscode.commands.executeCommand('workbench.action.openSettings', 'editless.github.repos');
+      await vscode.commands.executeCommand('workbench.action.openSettings', 'editless.github');
+    }),
+  );
+
+  // Configure ADO (opens settings)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.configureAdo', async () => {
+      await vscode.commands.executeCommand('workbench.action.openSettings', 'editless.ado');
     }),
   );
 

--- a/src/prs-tree.ts
+++ b/src/prs-tree.ts
@@ -77,13 +77,21 @@ export class PRsTreeProvider implements vscode.TreeDataProvider<PRsTreeItem> {
       }
 
       if (this._repos.length === 0) {
-        const item = new PRsTreeItem('Configure GitHub repos in settings');
-        item.iconPath = new vscode.ThemeIcon('info');
-        item.command = {
+        const ghItem = new PRsTreeItem('Configure in GitHub');
+        ghItem.iconPath = new vscode.ThemeIcon('github');
+        ghItem.command = {
           command: 'editless.configureRepos',
           title: 'Configure GitHub Repos',
         };
-        return [item];
+
+        const adoItem = new PRsTreeItem('Configure in ADO');
+        adoItem.iconPath = new vscode.ThemeIcon('azure');
+        adoItem.command = {
+          command: 'editless.configureAdo',
+          title: 'Configure Azure DevOps',
+        };
+
+        return [ghItem, adoItem];
       }
 
       if (this._prs.size === 0) {

--- a/src/work-items-tree.ts
+++ b/src/work-items-tree.ts
@@ -83,13 +83,21 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
       }
 
       if (this._repos.length === 0) {
-        const item = new WorkItemsTreeItem('Configure GitHub repos in settings');
-        item.iconPath = new vscode.ThemeIcon('info');
-        item.command = {
+        const ghItem = new WorkItemsTreeItem('Configure in GitHub');
+        ghItem.iconPath = new vscode.ThemeIcon('github');
+        ghItem.command = {
           command: 'editless.configureRepos',
           title: 'Configure GitHub Repos',
         };
-        return [item];
+
+        const adoItem = new WorkItemsTreeItem('Configure in ADO');
+        adoItem.iconPath = new vscode.ThemeIcon('azure');
+        adoItem.command = {
+          command: 'editless.configureAdo',
+          title: 'Configure Azure DevOps',
+        };
+
+        return [ghItem, adoItem];
       }
 
       if (this._issues.size === 0) {


### PR DESCRIPTION
Closes #102

When the Work Items or Pull Requests panes have no repos configured, they now show two configure links:
- **Configure in GitHub** — opens VS Code settings filtered to `editless.github`  
- **Configure in ADO** — opens VS Code settings filtered to `editless.ado`

Also adds `editless.ado.organization` and `editless.ado.project` settings as the foundation for future ADO integration.