### PR TITLE
feat: tree UX — click to expand, + button for new session (#144)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       {
         "command": "editless.launchSession",
         "title": "Launch Session",
-        "category": "EditLess"
+        "category": "EditLess",
+        "icon": "$(add)"
       },
       {
         "command": "editless.focusSession",
@@ -254,6 +255,7 @@
         { "command": "editless.refreshPRs", "when": "view == editlessPRs", "group": "navigation" }
       ],
       "view/item/context": [
+        { "command": "editless.launchSession", "when": "view == editlessTree && viewItem =~ /^squad|^agent$/", "group": "inline@0" },
         { "command": "editless.upgradeSquad", "when": "view == editlessTree && viewItem == squad-upgradeable", "group": "inline@1" },
         { "command": "editless.renameSquad", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@1" },
         { "command": "editless.changeModel", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@2" },

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -247,12 +247,6 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     item.tooltip = new vscode.MarkdownString(tooltipLines.join('\n\n'));
     item.iconPath = new vscode.ThemeIcon('organization');
 
-    item.command = {
-      command: 'editless.launchSession',
-      title: 'Launch Session',
-      arguments: [cfg.id],
-    };
-
     return item;
   }
 
@@ -366,7 +360,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     let children: EditlessTreeItem[];
     switch (kind) {
       case 'roster':
-        children = state.roster.map(a => this.buildAgentItem(a));
+        children = state.roster.map(a => this.buildAgentItem(a, squadId));
         break;
       case 'decisions':
         children = state.recentDecisions.map(d => this.buildDecisionItem(d));
@@ -385,8 +379,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     return children;
   }
 
-  private buildAgentItem(agent: AgentInfo): EditlessTreeItem {
-    const item = new EditlessTreeItem(agent.name, 'agent');
+  private buildAgentItem(agent: AgentInfo, squadId?: string): EditlessTreeItem {
+    const item = new EditlessTreeItem(agent.name, 'agent', vscode.TreeItemCollapsibleState.None, squadId);
     item.description = agent.role;
     item.iconPath = new vscode.ThemeIcon('person');
     return item;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,14 +259,16 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
 
   // Launch session
   context.subscriptions.push(
-    vscode.commands.registerCommand('editless.launchSession', async (squadId?: string) => {
+    vscode.commands.registerCommand('editless.launchSession', async (squadIdOrItem?: string | EditlessTreeItem) => {
       const squads = registry.loadSquads();
       if (squads.length === 0) {
         vscode.window.showWarningMessage('No agents registered yet.');
         return;
       }
 
-      let chosen: string | undefined = squadId;
+      let chosen: string | undefined = typeof squadIdOrItem === 'string'
+        ? squadIdOrItem
+        : squadIdOrItem?.squadId;
       if (!chosen) {
         const pick = await vscode.window.showQuickPick(
           squads.map(s => ({ label: `${s.icon} ${s.name}`, description: s.universe, id: s.id })),


### PR DESCRIPTION
Closes #144

Squad and agent nodes now expand/collapse on click (standard VS Code tree behavior). A `+` inline button on these nodes explicitly launches new sessions. Session leaf nodes still focus their terminal on click.

### Changes
- **editless-tree.ts**: Removed `command` property from squad items (parent nodes). Added `squadId` to agent items so the inline launch button resolves the correct squad.
- **extension.ts**: `editless.launchSession` handler now accepts both `string` (squadId) and `EditlessTreeItem` arguments, extracting `squadId` from tree items when invoked via inline button.
- **package.json**: Added `` icon to `editless.launchSession` command. Added `view/item/context` inline menu entry matching `viewItem =~ /^squad|^agent$/`.