### PR TITLE
fix: differentiate work item icons by plan status

### DIFF
--- a/src/__tests__/work-items-tree.test.ts
+++ b/src/__tests__/work-items-tree.test.ts
@@ -28,6 +28,12 @@ vi.mock('vscode', () => {
 
   class ThemeIcon {
     id: string;
+    color?: unknown;
+    constructor(id: string, color?: unknown) { this.id = id; this.color = color; }
+  }
+
+  class ThemeColor {
+    id: string;
     constructor(id: string) { this.id = id; }
   }
 
@@ -49,7 +55,7 @@ vi.mock('vscode', () => {
   }
 
   return {
-    TreeItem, TreeItemCollapsibleState, ThemeIcon, MarkdownString, EventEmitter,
+    TreeItem, TreeItemCollapsibleState, ThemeIcon, ThemeColor, MarkdownString, EventEmitter,
     Uri: { parse: (s: string) => ({ toString: () => s }) },
     workspace: {
       getConfiguration: () => ({
@@ -216,5 +222,26 @@ describe('WorkItemsTreeProvider — plan status indicators', () => {
       makeIssue({ number: 139, title: 'Fix icon bug', labels: ['status:planned'] }),
     ]);
     expect(items[0].label).toBe('📋 #139 Fix icon bug');
+  });
+
+  it('should use pass icon for planned items', async () => {
+    const items = await getIssueItems([makeIssue({ labels: ['status:planned'] })]);
+    const icon = items[0].iconPath as { id: string; color?: { id: string } };
+    expect(icon.id).toBe('pass');
+    expect(icon.color?.id).toBe('testing.iconPassed');
+  });
+
+  it('should use question icon for needs-plan items', async () => {
+    const items = await getIssueItems([makeIssue({ labels: ['status:needs-plan'] })]);
+    const icon = items[0].iconPath as { id: string; color?: { id: string } };
+    expect(icon.id).toBe('question');
+    expect(icon.color?.id).toBe('editorWarning.foreground');
+  });
+
+  it('should use issues icon for neutral items', async () => {
+    const items = await getIssueItems([makeIssue({ labels: ['bug'] })]);
+    const icon = items[0].iconPath as { id: string; color?: unknown };
+    expect(icon.id).toBe('issues');
+    expect(icon.color).toBeUndefined();
   });
 });

--- a/src/work-items-tree.ts
+++ b/src/work-items-tree.ts
@@ -214,7 +214,11 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
         ? `needs plan · ${labelText}`
         : labelText;
 
-    item.iconPath = new vscode.ThemeIcon('issues');
+    item.iconPath = hasPlan
+      ? new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'))
+      : needsPlan
+        ? new vscode.ThemeIcon('question', new vscode.ThemeColor('editorWarning.foreground'))
+        : new vscode.ThemeIcon('issues');
     item.contextValue = 'work-item';
 
     const planStatus = hasPlan ? '✓ planned' : needsPlan ? '❓ needs plan' : 'no status';


### PR DESCRIPTION
Closes #139

## Changes
- **Planned items** (status:planned): green pass icon with \	esting.iconPassed\ color
- **Needs-plan items** (status:needs-plan): yellow question icon with \ditorWarning.foreground\ color  
- **Neutral items**: unchanged default \issues\ icon

## Tests
- Added 3 new tests for icon differentiation
- Updated ThemeIcon/ThemeColor mocks
- All 18 work-items-tree tests pass