### PR TITLE
feat: support .squad folder rename alongside .ai-team

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
 # Squad: union merge for append-only team state files
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
 .ai-team/decisions.md merge=union
 .ai-team/agents/*/history.md merge=union
 .ai-team/log/** merge=union

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is EditLess?
 
-EditLess is a VS Code sidebar panel for managing AI coding agents. It auto-discovers agent teams in your workspace by scanning for `.ai-team/` directories, gives you terminal integration for launching and managing agent sessions, and supports multiple CLI providers (Copilot, Claude, and others) with auto-detection.
+EditLess is a VS Code sidebar panel for managing AI coding agents. It auto-discovers agent teams in your workspace by scanning for `.squad/` (or `.ai-team/`) directories, gives you terminal integration for launching and managing agent sessions, and supports multiple CLI providers (Copilot, Claude, and others) with auto-detection.
 
 EditLess uses progressive feature detection — features light up as tools are found in your environment. If you have no CLI tools installed, you still get basic terminal management. If you're working with [Squad CLI](https://github.com/bradygaster/squad) teams, you get enhanced features like roster views, decisions tracking, and activity monitoring. Nothing shows unless it's relevant.
 

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
           "type": "string",
           "default": "",
           "description": "Directory to scan for squad projects",
-          "markdownDescription": "Directory to scan for squad projects. EditLess watches this directory for folders containing `.ai-team/` structures and adds them to the Agents pane automatically.\n\n_This setting will be replaced by `#editless.discovery.scanPaths#` in a future release._",
+          "markdownDescription": "Directory to scan for squad projects. EditLess watches this directory for folders containing `.squad/` (or `.ai-team/`) structures and adds them to the Agents pane automatically.\n\n_This setting will be replaced by `#editless.discovery.scanPaths#` in a future release._",
           "scope": "resource",
           "order": 2
         },


### PR DESCRIPTION
Closes #93

## Changes
- **.gitattributes**: Added \.squad/\ patterns for union merge driver (alongside existing \.ai-team/\ patterns)
- **package.json**: Updated setting description to mention \.squad/\ as primary directory
- **README.md**: Updated to reference \.squad/\ as primary, \.ai-team/\ as fallback

## Context
Runtime code already supports both directories via \esolveTeamDir()\ / \esolveTeamMd()\ in \src/team-dir.ts\ — this PR closes the documentation and config gaps.