### PR TITLE
feat: auto-flush decisions inbox on activation

### DIFF
--- a/src/__tests__/inbox-flusher.test.ts
+++ b/src/__tests__/inbox-flusher.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { flushDecisionsInbox } from '../inbox-flusher';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inbox-flusher-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(relPath: string, content: string): void {
+  const fullPath = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf-8');
+}
+
+describe('flushDecisionsInbox', () => {
+  it('should return zero flushed when inbox dir does not exist', () => {
+    const result = flushDecisionsInbox(tmpDir);
+    expect(result.flushed).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should return zero flushed when inbox is empty', () => {
+    fs.mkdirSync(path.join(tmpDir, 'decisions', 'inbox'), { recursive: true });
+    const result = flushDecisionsInbox(tmpDir);
+    expect(result.flushed).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should append inbox file content to decisions.md and delete inbox files', () => {
+    writeFile('decisions.md', '### 2026-02-01: Existing decision\nSome content\n');
+    writeFile('decisions/inbox/new-decision.md', '### 2026-02-16: New decision\n**By:** Scribe\nA new decision.');
+
+    const result = flushDecisionsInbox(tmpDir);
+
+    expect(result.flushed).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const decisionsContent = fs.readFileSync(path.join(tmpDir, 'decisions.md'), 'utf-8');
+    expect(decisionsContent).toContain('Existing decision');
+    expect(decisionsContent).toContain('New decision');
+
+    const inboxFiles = fs.readdirSync(path.join(tmpDir, 'decisions', 'inbox'));
+    expect(inboxFiles).toHaveLength(0);
+  });
+
+  it('should flush multiple inbox files', () => {
+    writeFile('decisions.md', '# Decisions\n');
+    writeFile('decisions/inbox/a.md', '### 2026-02-16: Decision A\nContent A');
+    writeFile('decisions/inbox/b.md', '### 2026-02-16: Decision B\nContent B');
+
+    const result = flushDecisionsInbox(tmpDir);
+
+    expect(result.flushed).toBe(2);
+    const content = fs.readFileSync(path.join(tmpDir, 'decisions.md'), 'utf-8');
+    expect(content).toContain('Decision A');
+    expect(content).toContain('Decision B');
+  });
+
+  it('should skip non-md files in inbox', () => {
+    writeFile('decisions.md', '');
+    writeFile('decisions/inbox/decision.md', 'A decision');
+    writeFile('decisions/inbox/notes.txt', 'Not a decision');
+
+    const result = flushDecisionsInbox(tmpDir);
+    expect(result.flushed).toBe(1);
+
+    // .txt file should remain
+    expect(fs.existsSync(path.join(tmpDir, 'decisions', 'inbox', 'notes.txt'))).toBe(true);
+  });
+
+  it('should create decisions.md if it does not exist', () => {
+    writeFile('decisions/inbox/first.md', '### 2026-02-16: First\nContent');
+
+    const result = flushDecisionsInbox(tmpDir);
+    expect(result.flushed).toBe(1);
+
+    const content = fs.readFileSync(path.join(tmpDir, 'decisions.md'), 'utf-8');
+    expect(content).toContain('First');
+  });
+
+  it('should skip empty inbox files without errors', () => {
+    writeFile('decisions.md', '');
+    writeFile('decisions/inbox/empty.md', '');
+    writeFile('decisions/inbox/content.md', 'Real content');
+
+    const result = flushDecisionsInbox(tmpDir);
+    expect(result.flushed).toBe(2);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/inbox-flusher.ts
+++ b/src/inbox-flusher.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FlushResult {
+  flushed: number;
+  errors: string[];
+}
+
+/**
+ * Reads all .md files from the decisions inbox, appends their content
+ * to decisions.md, and deletes the inbox files.
+ * Returns silently if inbox is empty or doesn't exist.
+ */
+export function flushDecisionsInbox(teamDir: string): FlushResult {
+  const inboxDir = path.join(teamDir, 'decisions', 'inbox');
+  const decisionsFile = path.join(teamDir, 'decisions.md');
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(inboxDir, { withFileTypes: true });
+  } catch {
+    return { flushed: 0, errors: [] };
+  }
+
+  const mdFiles = entries.filter(e => e.isFile() && e.name.endsWith('.md'));
+  if (mdFiles.length === 0) {
+    return { flushed: 0, errors: [] };
+  }
+
+  const errors: string[] = [];
+  const chunks: string[] = [];
+
+  for (const file of mdFiles) {
+    const filePath = path.join(inboxDir, file.name);
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8').trim();
+      if (content.length > 0) {
+        chunks.push(content);
+      }
+    } catch (err) {
+      errors.push(`Failed to read ${file.name}: ${err}`);
+    }
+  }
+
+  if (chunks.length > 0) {
+    const separator = '\n\n';
+    const appendText = separator + chunks.join(separator) + '\n';
+    try {
+      fs.appendFileSync(decisionsFile, appendText, 'utf-8');
+    } catch (err) {
+      return { flushed: 0, errors: [`Failed to write decisions.md: ${err}`] };
+    }
+  }
+
+  let flushed = 0;
+  for (const file of mdFiles) {
+    const filePath = path.join(inboxDir, file.name);
+    try {
+      fs.unlinkSync(filePath);
+      flushed++;
+    } catch (err) {
+      errors.push(`Failed to delete ${file.name}: ${err}`);
+    }
+  }
+
+  return { flushed, errors };
+}


### PR DESCRIPTION
Closes #66

## Changes
- **New \src/inbox-flusher.ts\**: Reads \.md\ files from \decisions/inbox/\, appends content to \decisions.md\, deletes inbox files
- **\src/extension.ts\**: Calls \lushDecisionsInbox()\ for each registered squad during activation
- Silently no-ops if inbox is empty or doesn't exist (no empty commits)

## Tests
- 7 unit tests in \src/__tests__/inbox-flusher.test.ts\
- Covers: empty inbox, missing inbox, single/multi flush, non-md skip, decisions.md creation, empty file handling