### PR TITLE
feat: persist session IDs across VS Code crashes

### DIFF
--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -226,6 +226,9 @@ vi.mock('../terminal-manager', () => ({
       relaunchAllOrphans: mockRelaunchAllOrphans,
       persist: vi.fn(),
       reconcile: vi.fn(),
+      setSessionResolver: vi.fn(),
+      setAgentSessionId: vi.fn(),
+      getOrphanedSessions: vi.fn().mockReturnValue([]),
       onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
       dispose: vi.fn(),
     };


### PR DESCRIPTION
Closes #94

Added squadPath field, 30s periodic persist timer, session ID auto-detection via SessionContextResolver, crash recovery notification, and cwd restoration on relaunch. All 421 tests pass.
