### PR TITLE
feat: Squad UI extension integration (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npm run build
 - [GitHub Workflow](docs/workflows/github-workflow.md) — Managing work with AI agents on GitHub
 - [ADO Workflow](docs/workflows/ado-workflow.md) — Managing work with AI agents on Azure DevOps
 
+## Companion Extensions
+
+- **[SquadUI](https://marketplace.visualstudio.com/items?itemName=csharpfritz.squadui)** — Visualize team state, manage skills, view the squad dashboard. When SquadUI is installed, EditLess adds "Open in Squad UI" to squad context menus for quick cross-linking.
+
 ## License
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
         "title": "Go to Settings"
       },
       {
+        "command": "editless.openInSquadUi",
+        "title": "Open in Squad UI",
+        "icon": "$(link-external)"
+      },
+      {
         "command": "editless.changeModel",
         "title": "Change Model"
       },
@@ -270,7 +275,8 @@
         { "command": "editless.renameSquad", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@1" },
         { "command": "editless.changeModel", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@2" },
         { "command": "editless.goToSquadSettings", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@3" },
-        { "command": "editless.hideAgent", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@4" },
+        { "command": "editless.openInSquadUi", "when": "view == editlessTree && viewItem =~ /^squad/ && editless.squadUiAvailable", "group": "squad@4" },
+        { "command": "editless.hideAgent", "when": "view == editlessTree && viewItem =~ /^squad/", "group": "squad@5" },
         { "command": "editless.hideAgent", "when": "view == editlessTree && viewItem == discovered-agent", "group": "inline" },
         { "command": "editless.closeTerminal", "when": "viewItem == terminal" },
         { "command": "editless.closeTerminal", "when": "viewItem == terminal", "group": "inline@99" },
@@ -290,6 +296,7 @@
         { "command": "editless.renameSquad", "when": "false" },
         { "command": "editless.changeModel", "when": "false" },
         { "command": "editless.goToSquadSettings", "when": "false" },
+        { "command": "editless.openInSquadUi", "when": "false" },
         { "command": "editless.hideAgent", "when": "false" },
         { "command": "editless.refreshWorkItems", "when": "false" },
         { "command": "editless.refreshPRs", "when": "false" },

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -181,6 +181,10 @@ vi.mock('vscode', () => {
       openExternal: mockOpenExternal,
       clipboard: { writeText: vi.fn() },
     },
+    extensions: {
+      getExtension: vi.fn(),
+      onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+    },
     ProgressLocation: { Notification: 15 },
   };
 });

--- a/src/__tests__/squad-ui-integration.test.ts
+++ b/src/__tests__/squad-ui-integration.test.ts
@@ -1,0 +1,121 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const { mockGetExtension, mockExecuteCommand, mockOnDidChange } = vi.hoisted(() => ({
+  mockGetExtension: vi.fn(),
+  mockExecuteCommand: vi.fn(),
+  mockOnDidChange: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  extensions: {
+    getExtension: mockGetExtension,
+    onDidChange: mockOnDidChange,
+  },
+  commands: {
+    executeCommand: mockExecuteCommand,
+  },
+}));
+
+import {
+  isSquadUiInstalled,
+  initSquadUiContext,
+  openSquadUiDashboard,
+  openSquadUiCharter,
+} from '../squad-ui-integration';
+import type * as vscode from 'vscode';
+
+function makeMockContext(): vscode.ExtensionContext {
+  return {
+    subscriptions: [],
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe('squad-ui-integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnDidChange.mockReturnValue({ dispose: vi.fn() });
+  });
+
+  describe('isSquadUiInstalled', () => {
+    it('should return true when SquadUI extension is installed', () => {
+      mockGetExtension.mockReturnValue({ id: 'csharpfritz.squadui' });
+      expect(isSquadUiInstalled()).toBe(true);
+    });
+
+    it('should return false when SquadUI extension is not installed', () => {
+      mockGetExtension.mockReturnValue(undefined);
+      expect(isSquadUiInstalled()).toBe(false);
+    });
+
+    it('should query the correct extension ID', () => {
+      isSquadUiInstalled();
+      expect(mockGetExtension).toHaveBeenCalledWith('csharpfritz.squadui');
+    });
+  });
+
+  describe('initSquadUiContext', () => {
+    it('should set context key to true when SquadUI is installed', () => {
+      mockGetExtension.mockReturnValue({ id: 'csharpfritz.squadui' });
+      initSquadUiContext(makeMockContext());
+      expect(mockExecuteCommand).toHaveBeenCalledWith('setContext', 'editless.squadUiAvailable', true);
+    });
+
+    it('should set context key to false when SquadUI is not installed', () => {
+      mockGetExtension.mockReturnValue(undefined);
+      initSquadUiContext(makeMockContext());
+      expect(mockExecuteCommand).toHaveBeenCalledWith('setContext', 'editless.squadUiAvailable', false);
+    });
+
+    it('should register onDidChange listener for extension install/uninstall', () => {
+      initSquadUiContext(makeMockContext());
+      expect(mockOnDidChange).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should update context key when extensions change', () => {
+      let changeListener: () => void;
+      mockOnDidChange.mockImplementation((listener: () => void) => {
+        changeListener = listener;
+        return { dispose: vi.fn() };
+      });
+
+      mockGetExtension.mockReturnValue(undefined);
+      initSquadUiContext(makeMockContext());
+
+      // Simulate SquadUI being installed
+      mockGetExtension.mockReturnValue({ id: 'csharpfritz.squadui' });
+      mockExecuteCommand.mockClear();
+      changeListener!();
+      expect(mockExecuteCommand).toHaveBeenCalledWith('setContext', 'editless.squadUiAvailable', true);
+    });
+
+    it('should push disposable to subscriptions', () => {
+      const ctx = makeMockContext();
+      initSquadUiContext(ctx);
+      expect(ctx.subscriptions).toHaveLength(1);
+    });
+  });
+
+  describe('openSquadUiDashboard', () => {
+    it('should call squadui.openDashboard command', async () => {
+      await openSquadUiDashboard();
+      expect(mockExecuteCommand).toHaveBeenCalledWith('squadui.openDashboard');
+    });
+
+    it('should not throw when command is unavailable', async () => {
+      mockExecuteCommand.mockRejectedValue(new Error('command not found'));
+      await expect(openSquadUiDashboard()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('openSquadUiCharter', () => {
+    it('should call squadui.viewCharter command', async () => {
+      await openSquadUiCharter();
+      expect(mockExecuteCommand).toHaveBeenCalledWith('squadui.viewCharter');
+    });
+
+    it('should not throw when command is unavailable', async () => {
+      mockExecuteCommand.mockRejectedValue(new Error('command not found'));
+      await expect(openSquadUiCharter()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { NotificationManager } from './notifications';
 import { SessionContextResolver } from './session-context';
 import { scanSquad } from './scanner';
 import { flushDecisionsInbox } from './inbox-flusher';
+import { initSquadUiContext, openSquadUiDashboard } from './squad-ui-integration';
 import { resolveTeamDir } from './team-dir';
 import { WorkItemsTreeProvider, WorkItemsTreeItem } from './work-items-tree';
 import { PRsTreeProvider, PRsTreeItem } from './prs-tree';
@@ -36,6 +37,9 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   // --- CLI provider detection (async, non-blocking) -------------------------
   vscode.commands.executeCommand('setContext', 'editless.agencyUpdateAvailable', false);
   probeAllProviders().then(() => resolveActiveProvider());
+
+  // --- Squad UI integration (#38) ------------------------------------------
+  initSquadUiContext(context);
 
   // --- Registry ----------------------------------------------------------
   const registry = createRegistry(context);
@@ -551,6 +555,11 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
         initAdoIntegration(context, workItemsProvider, prsProvider);
       }
     }),
+  );
+
+  // Open in Squad UI (context menu on squads — visible only when SquadUI is installed)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.openInSquadUi', () => openSquadUiDashboard()),
   );
 
   // Open in Browser (context menu for work items and PRs)

--- a/src/squad-ui-integration.ts
+++ b/src/squad-ui-integration.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+
+const SQUAD_UI_EXTENSION_ID = 'csharpfritz.squadui';
+
+export function isSquadUiInstalled(): boolean {
+  return vscode.extensions.getExtension(SQUAD_UI_EXTENSION_ID) !== undefined;
+}
+
+export function initSquadUiContext(context: vscode.ExtensionContext): void {
+  vscode.commands.executeCommand('setContext', 'editless.squadUiAvailable', isSquadUiInstalled());
+
+  context.subscriptions.push(
+    vscode.extensions.onDidChange(() => {
+      vscode.commands.executeCommand('setContext', 'editless.squadUiAvailable', isSquadUiInstalled());
+    }),
+  );
+}
+
+export async function openSquadUiDashboard(): Promise<void> {
+  try {
+    await vscode.commands.executeCommand('squadui.openDashboard');
+  } catch {
+    // SquadUI command may not exist in older versions
+  }
+}
+
+export async function openSquadUiCharter(): Promise<void> {
+  try {
+    await vscode.commands.executeCommand('squadui.viewCharter');
+  } catch {
+    // SquadUI command may not exist in older versions
+  }
+}


### PR DESCRIPTION
## Summary

Lightweight Squad UI extension integration. Closes #38.

### What it does

- Detects if [SquadUI](https://marketplace.visualstudio.com/items?itemName=csharpfritz.squadui) is installed
- Sets `editless.squadUiAvailable` context key (updates on extension install/uninstall)
- Adds "Open in Squad UI" to squad right-click menu (only visible when SquadUI is present)
- Cross-links to `squadui.openDashboard` with try/catch for version safety

### Files

| File | Change |
|---|---|
| `src/squad-ui-integration.ts` | New: detection, context key, cross-link commands |
| `src/__tests__/squad-ui-integration.test.ts` | New: 12 tests |
| `src/extension.ts` | Wire init + register command |
| `package.json` | Command + menu entry + commandPalette |
| `README.md` | Companion Extensions section |
| `src/__tests__/extension-commands.test.ts` | Add `extensions` to vscode mock |

### Known limitation

Multi-squad: SquadUI commands don't accept a squad path argument, so cross-link targets whichever squad SquadUI has active. Works well for single-squad workspaces (common case).
