### PR TITLE
feat: work items tree filter by repo, label, and state (#132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,18 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "editless.filterWorkItems",
+        "title": "Filter Work Items",
+        "category": "EditLess",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "editless.clearWorkItemsFilter",
+        "title": "Clear Work Items Filter",
+        "category": "EditLess",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "editless.refreshPRs",
         "title": "Refresh PRs",
         "category": "EditLess",
@@ -266,7 +278,9 @@
         { "command": "editless.addSquad", "when": "view == editlessTree", "group": "navigation@4" },
         { "command": "editless.updateAgency", "when": "view == editlessTree && editless.agencyUpdateAvailable", "group": "1_updates" },
         { "command": "editless.upgradeAllSquads", "when": "view == editlessTree", "group": "1_updates" },
-        { "command": "editless.refreshWorkItems", "when": "view == editlessWorkItems", "group": "navigation" },
+        { "command": "editless.refreshWorkItems", "when": "view == editlessWorkItems", "group": "navigation@1" },
+        { "command": "editless.filterWorkItems", "when": "view == editlessWorkItems", "group": "navigation@2" },
+        { "command": "editless.clearWorkItemsFilter", "when": "view == editlessWorkItems && editless.workItemsFiltered", "group": "navigation@3" },
         { "command": "editless.refreshPRs", "when": "view == editlessPRs", "group": "navigation" }
       ],
       "view/item/context": [
@@ -299,6 +313,8 @@
         { "command": "editless.openInSquadUi", "when": "false" },
         { "command": "editless.hideAgent", "when": "false" },
         { "command": "editless.refreshWorkItems", "when": "false" },
+        { "command": "editless.filterWorkItems", "when": "false" },
+        { "command": "editless.clearWorkItemsFilter", "when": "false" },
         { "command": "editless.refreshPRs", "when": "false" },
         { "command": "editless.openInBrowser", "when": "false" },
         { "command": "editless.launchFromWorkItem", "when": "false" },

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -153,7 +153,7 @@ vi.mock('vscode', () => {
       showWarningMessage: mockShowWarningMessage,
       showInformationMessage: mockShowInformationMessage,
       createOutputChannel: () => ({ appendLine: vi.fn(), dispose: vi.fn() }),
-      createTreeView: () => ({ reveal: vi.fn(), dispose: vi.fn() }),
+      createTreeView: () => ({ reveal: vi.fn(), dispose: vi.fn(), description: undefined }),
       registerTreeDataProvider: () => ({ dispose: vi.fn() }),
       onDidChangeActiveTerminal: vi.fn(() => ({ dispose: vi.fn() })),
       onDidOpenTerminal: vi.fn(() => ({ dispose: vi.fn() })),
@@ -186,6 +186,7 @@ vi.mock('vscode', () => {
       onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
     },
     ProgressLocation: { Notification: 15 },
+    QuickPickItemKind: { Separator: -1, Default: 0 },
   };
 });
 
@@ -321,6 +322,13 @@ vi.mock('../work-items-tree', () => ({
     return {
       setRepos: vi.fn(),
       refresh: mockWorkItemsRefresh,
+      setTreeView: vi.fn(),
+      setFilter: vi.fn(),
+      clearFilter: vi.fn(),
+      filter: { repos: [], labels: [], states: [] },
+      isFiltered: false,
+      getAllRepos: vi.fn().mockReturnValue([]),
+      getAllLabels: vi.fn().mockReturnValue([]),
     };
   }),
   WorkItemsTreeItem: class {},

--- a/src/__tests__/work-items-tree.test.ts
+++ b/src/__tests__/work-items-tree.test.ts
@@ -57,6 +57,9 @@ vi.mock('vscode', () => {
   return {
     TreeItem, TreeItemCollapsibleState, ThemeIcon, ThemeColor, MarkdownString, EventEmitter,
     Uri: { parse: (s: string) => ({ toString: () => s }) },
+    commands: {
+      executeCommand: vi.fn(),
+    },
     workspace: {
       getConfiguration: () => ({
         get: () => ({}),
@@ -70,7 +73,7 @@ vi.mock('../github-client', () => ({
   fetchAssignedIssues: (...args: unknown[]) => mockFetchAssignedIssues(...(args as [string])),
 }));
 
-import { WorkItemsTreeProvider, WorkItemsTreeItem } from '../work-items-tree';
+import { WorkItemsTreeProvider, WorkItemsTreeItem, mapGitHubState, mapAdoState } from '../work-items-tree';
 import type { GitHubIssue } from '../github-client';
 
 beforeEach(() => {
@@ -243,5 +246,159 @@ describe('WorkItemsTreeProvider — plan status indicators', () => {
     const icon = items[0].iconPath as { id: string; color?: unknown };
     expect(icon.id).toBe('issues');
     expect(icon.color).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapGitHubState / mapAdoState (#132)
+// ---------------------------------------------------------------------------
+
+describe('mapGitHubState', () => {
+  it('should return "active" for open issues with assignees', () => {
+    expect(mapGitHubState(makeIssue({ state: 'open', assignees: ['user'] }))).toBe('active');
+  });
+
+  it('should return "open" for open issues with no assignees', () => {
+    expect(mapGitHubState(makeIssue({ state: 'open', assignees: [] }))).toBe('open');
+  });
+
+  it('should return "closed" for closed issues', () => {
+    expect(mapGitHubState(makeIssue({ state: 'closed' }))).toBe('closed');
+  });
+});
+
+describe('mapAdoState', () => {
+  it('should map "New" to "open"', () => {
+    expect(mapAdoState('New')).toBe('open');
+  });
+
+  it('should map "Active" to "active"', () => {
+    expect(mapAdoState('Active')).toBe('active');
+  });
+
+  it('should map "Resolved" to "closed"', () => {
+    expect(mapAdoState('Resolved')).toBe('closed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime filtering (#132)
+// ---------------------------------------------------------------------------
+
+describe('WorkItemsTreeProvider — runtime filter', () => {
+  async function getFilteredItems(
+    issues: GitHubIssue[],
+    filter: { repos?: string[]; labels?: string[]; states?: Array<'open' | 'active' | 'closed'> },
+  ): Promise<WorkItemsTreeItem[]> {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchAssignedIssues.mockResolvedValue(issues);
+
+    const provider = new WorkItemsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    provider.setFilter({
+      repos: filter.repos ?? [],
+      labels: filter.labels ?? [],
+      states: filter.states ?? [],
+    });
+
+    return provider.getChildren();
+  }
+
+  it('should filter by label', async () => {
+    const items = await getFilteredItems(
+      [makeIssue({ number: 1, labels: ['bug'] }), makeIssue({ number: 2, labels: ['feature'] })],
+      { labels: ['bug'] },
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toContain('#1');
+  });
+
+  it('should filter by state (active = assigned)', async () => {
+    const items = await getFilteredItems(
+      [makeIssue({ number: 1, assignees: ['user'] }), makeIssue({ number: 2, assignees: [] })],
+      { states: ['active'] },
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toContain('#1');
+  });
+
+  it('should filter by state (open = unassigned)', async () => {
+    const items = await getFilteredItems(
+      [makeIssue({ number: 1, assignees: ['user'] }), makeIssue({ number: 2, assignees: [] })],
+      { states: ['open'] },
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toContain('#2');
+  });
+
+  it('should show empty state message when filter excludes all items', async () => {
+    const items = await getFilteredItems(
+      [makeIssue({ labels: ['bug'] })],
+      { labels: ['nonexistent'] },
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe('No items match current filter');
+  });
+
+  it('should return all items when filter is empty', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchAssignedIssues.mockResolvedValue([makeIssue({ number: 1 }), makeIssue({ number: 2 })]);
+
+    const provider = new WorkItemsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    provider.setFilter({ repos: [], labels: [], states: [] });
+    const items = provider.getChildren();
+    expect(items).toHaveLength(2);
+  });
+
+  it('should clear filter and show all items', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchAssignedIssues.mockResolvedValue([makeIssue({ number: 1, labels: ['bug'] }), makeIssue({ number: 2 })]);
+
+    const provider = new WorkItemsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    provider.setFilter({ repos: [], labels: ['bug'], states: [] });
+    expect(provider.getChildren()).toHaveLength(1);
+
+    provider.clearFilter();
+    expect(provider.getChildren()).toHaveLength(2);
+  });
+
+  it('should report isFiltered correctly', () => {
+    const provider = new WorkItemsTreeProvider();
+    expect(provider.isFiltered).toBe(false);
+    provider.setFilter({ repos: ['test'], labels: [], states: [] });
+    expect(provider.isFiltered).toBe(true);
+    provider.clearFilter();
+    expect(provider.isFiltered).toBe(false);
+  });
+
+  it('should collect all unique labels from issues', async () => {
+    mockIsGhAvailable.mockResolvedValue(true);
+    mockFetchAssignedIssues.mockResolvedValue([
+      makeIssue({ labels: ['bug', 'urgent'] }),
+      makeIssue({ labels: ['bug', 'feature'] }),
+    ]);
+
+    const provider = new WorkItemsTreeProvider();
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.setRepos(['owner/repo']);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
+    const labels = provider.getAllLabels();
+    expect(labels).toEqual(['bug', 'feature', 'urgent']);
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { scanSquad } from './scanner';
 import { flushDecisionsInbox } from './inbox-flusher';
 import { initSquadUiContext, openSquadUiDashboard } from './squad-ui-integration';
 import { resolveTeamDir } from './team-dir';
-import { WorkItemsTreeProvider, WorkItemsTreeItem } from './work-items-tree';
+import { WorkItemsTreeProvider, WorkItemsTreeItem, type UnifiedState } from './work-items-tree';
 import { PRsTreeProvider, PRsTreeItem } from './prs-tree';
 import { fetchLinkedPRs } from './github-client';
 import { getEdition } from './vscode-compat';
@@ -87,7 +87,9 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
 
   // --- Work Items tree view ------------------------------------------------
   const workItemsProvider = new WorkItemsTreeProvider();
-  context.subscriptions.push(vscode.window.registerTreeDataProvider('editlessWorkItems', workItemsProvider));
+  const workItemsView = vscode.window.createTreeView('editlessWorkItems', { treeDataProvider: workItemsProvider });
+  workItemsProvider.setTreeView(workItemsView);
+  context.subscriptions.push(workItemsView);
 
   // --- PRs tree view -------------------------------------------------------
   const prsProvider = new PRsTreeProvider();
@@ -514,6 +516,54 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
     vscode.commands.registerCommand('editless.refreshWorkItems', () => workItemsProvider.refresh()),
     vscode.commands.registerCommand('editless.refreshPRs', () => prsProvider.refresh()),
   );
+
+  // Filter work items (#132)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.filterWorkItems', async () => {
+      const current = workItemsProvider.filter;
+      const allRepos = workItemsProvider.getAllRepos();
+      const allLabels = workItemsProvider.getAllLabels();
+      const stateOptions: { label: string; value: UnifiedState }[] = [
+        { label: 'Open (New)', value: 'open' },
+        { label: 'Active / In Progress', value: 'active' },
+      ];
+
+      const items: vscode.QuickPickItem[] = [];
+      if (allRepos.length > 0) {
+        items.push({ label: 'Repos', kind: vscode.QuickPickItemKind.Separator });
+        for (const repo of allRepos) {
+          items.push({ label: repo, description: 'repo', picked: current.repos.includes(repo) });
+        }
+      }
+      items.push({ label: 'State', kind: vscode.QuickPickItemKind.Separator });
+      for (const s of stateOptions) {
+        items.push({ label: s.label, description: 'state', picked: current.states.includes(s.value) });
+      }
+      if (allLabels.length > 0) {
+        items.push({ label: 'Labels', kind: vscode.QuickPickItemKind.Separator });
+        for (const label of allLabels) {
+          items.push({ label, description: 'label', picked: current.labels.includes(label) });
+        }
+      }
+
+      const picks = await vscode.window.showQuickPick(items, {
+        title: 'Filter Work Items',
+        canPickMany: true,
+        placeHolder: 'Select filters (leave empty to show all)',
+      });
+      if (picks === undefined) return;
+
+      const repos = picks.filter(p => p.description === 'repo').map(p => p.label);
+      const labels = picks.filter(p => p.description === 'label').map(p => p.label);
+      const states = picks.filter(p => p.description === 'state')
+        .map(p => stateOptions.find(s => s.label === p.label)?.value)
+        .filter((s): s is UnifiedState => s !== undefined);
+
+      workItemsProvider.setFilter({ repos, labels, states });
+    }),
+    vscode.commands.registerCommand('editless.clearWorkItemsFilter', () => workItemsProvider.clearFilter()),
+  );
+  vscode.commands.executeCommand('setContext', 'editless.workItemsFiltered', false);
 
   // Configure GitHub repos (opens settings)
   context.subscriptions.push(

--- a/src/work-items-tree.ts
+++ b/src/work-items-tree.ts
@@ -7,6 +7,26 @@ interface IssueFilter {
   excludeLabels?: string[];
 }
 
+export type UnifiedState = 'open' | 'active' | 'closed';
+
+export function mapGitHubState(issue: GitHubIssue): UnifiedState {
+  if (issue.state === 'closed') return 'closed';
+  return issue.assignees.length > 0 ? 'active' : 'open';
+}
+
+export function mapAdoState(state: string): UnifiedState {
+  const lower = state.toLowerCase();
+  if (lower === 'new') return 'open';
+  if (lower === 'active' || lower === 'doing') return 'active';
+  return 'closed';
+}
+
+export interface WorkItemsFilter {
+  repos: string[];
+  labels: string[];
+  states: UnifiedState[];
+}
+
 export class WorkItemsTreeItem extends vscode.TreeItem {
   public issue?: GitHubIssue;
   public adoWorkItem?: AdoWorkItem;
@@ -28,6 +48,8 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
   private _adoItems: AdoWorkItem[] = [];
   private _adoConfigured = false;
   private _loading = false;
+  private _filter: WorkItemsFilter = { repos: [], labels: [], states: [] };
+  private _treeView?: vscode.TreeView<WorkItemsTreeItem>;
 
   setRepos(repos: string[]): void {
     this._repos = repos;
@@ -44,6 +66,62 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
     this._adoItems = [];
     this._adoConfigured = false;
     this._onDidChangeTreeData.fire();
+  }
+
+  setTreeView(view: vscode.TreeView<WorkItemsTreeItem>): void {
+    this._treeView = view;
+    this._updateDescription();
+  }
+
+  get filter(): WorkItemsFilter {
+    return { ...this._filter };
+  }
+
+  get isFiltered(): boolean {
+    return this._filter.repos.length > 0 || this._filter.labels.length > 0 || this._filter.states.length > 0;
+  }
+
+  setFilter(filter: WorkItemsFilter): void {
+    this._filter = { ...filter };
+    vscode.commands.executeCommand('setContext', 'editless.workItemsFiltered', this.isFiltered);
+    this._updateDescription();
+    this._onDidChangeTreeData.fire();
+  }
+
+  clearFilter(): void {
+    this.setFilter({ repos: [], labels: [], states: [] });
+  }
+
+  private _updateDescription(): void {
+    if (!this._treeView) return;
+    if (!this.isFiltered) {
+      this._treeView.description = undefined;
+      return;
+    }
+    const parts: string[] = [];
+    if (this._filter.repos.length > 0) parts.push(`repo:${this._filter.repos.join(',')}`);
+    if (this._filter.labels.length > 0) parts.push(`label:${this._filter.labels.join(',')}`);
+    if (this._filter.states.length > 0) parts.push(`state:${this._filter.states.join(',')}`);
+    this._treeView.description = parts.join(' · ');
+  }
+
+  getAllLabels(): string[] {
+    const labels = new Set<string>();
+    for (const issues of this._issues.values()) {
+      for (const issue of issues) {
+        for (const label of issue.labels) labels.add(label);
+      }
+    }
+    for (const wi of this._adoItems) {
+      for (const tag of wi.tags) labels.add(tag);
+    }
+    return [...labels].sort();
+  }
+
+  getAllRepos(): string[] {
+    const repos = [...this._repos];
+    if (this._adoConfigured) repos.push('(ADO)');
+    return repos;
   }
 
   refresh(): void {
@@ -116,12 +194,22 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
         return [ghItem, adoItem];
       }
 
-      const hasGitHub = this._issues.size > 0;
-      const hasAdo = this._adoItems.length > 0;
+      // Apply runtime filters
+      const filteredIssues = new Map<string, GitHubIssue[]>();
+      for (const [repo, issues] of this._issues.entries()) {
+        const filtered = this.applyRuntimeFilter(issues);
+        if (filtered.length > 0) filteredIssues.set(repo, filtered);
+      }
+      const filteredAdo = this.applyAdoRuntimeFilter(this._adoItems);
+
+      const hasGitHub = filteredIssues.size > 0;
+      const hasAdo = filteredAdo.length > 0;
 
       if (!hasGitHub && !hasAdo) {
-        const item = new WorkItemsTreeItem('No assigned issues found');
-        item.iconPath = new vscode.ThemeIcon('check');
+        const msg = this.isFiltered ? 'No items match current filter' : 'No assigned issues found';
+        const icon = this.isFiltered ? 'filter' : 'check';
+        const item = new WorkItemsTreeItem(msg);
+        item.iconPath = new vscode.ThemeIcon(icon);
         return [item];
       }
 
@@ -132,28 +220,28 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
         if (hasGitHub) {
           const adoGroup = new WorkItemsTreeItem('Azure DevOps', vscode.TreeItemCollapsibleState.Expanded);
           adoGroup.iconPath = new vscode.ThemeIcon('azure');
-          adoGroup.description = `${this._adoItems.length} item${this._adoItems.length === 1 ? '' : 's'}`;
+          adoGroup.description = `${filteredAdo.length} item${filteredAdo.length === 1 ? '' : 's'}`;
           adoGroup.contextValue = 'ado-group';
           adoGroup.id = 'wi:ado';
           items.push(adoGroup);
         } else {
-          return this._adoItems.map(wi => this.buildAdoItem(wi));
+          return filteredAdo.map(wi => this.buildAdoItem(wi));
         }
       }
 
       // GitHub issues (existing logic)
       if (hasGitHub) {
-        const milestoneItems = this.buildMilestoneGroups();
+        const milestoneItems = this.buildMilestoneGroups(filteredIssues);
         if (milestoneItems && !hasAdo) {
           return milestoneItems;
         }
         if (milestoneItems && hasAdo) {
           items.push(...milestoneItems);
-        } else if (this._issues.size === 1 && !hasAdo) {
-          const [, issues] = [...this._issues.entries()][0];
+        } else if (filteredIssues.size === 1 && !hasAdo) {
+          const [, issues] = [...filteredIssues.entries()][0];
           return issues.map((i) => this.buildIssueItem(i));
         } else {
-          for (const [repo, issues] of this._issues.entries()) {
+          for (const [repo, issues] of filteredIssues.entries()) {
             const repoItem = new WorkItemsTreeItem(repo, vscode.TreeItemCollapsibleState.Expanded);
             repoItem.iconPath = new vscode.ThemeIcon('github');
             repoItem.description = `${issues.length} issue${issues.length === 1 ? '' : 's'}`;
@@ -168,12 +256,12 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
     }
 
     if (element.contextValue === 'ado-group') {
-      return this._adoItems.map(wi => this.buildAdoItem(wi));
+      return this.applyAdoRuntimeFilter(this._adoItems).map(wi => this.buildAdoItem(wi));
     }
 
     if (element.contextValue === 'milestone-group') {
       const msName = element.id?.replace('ms:', '') ?? '';
-      const allIssues = [...this._issues.values()].flat();
+      const allIssues = this.applyRuntimeFilter([...this._issues.values()].flat());
       const filtered = msName === '__none__'
         ? allIssues.filter((i) => !i.milestone)
         : allIssues.filter((i) => i.milestone === msName);
@@ -182,7 +270,7 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
 
     const repoId = element.id?.replace('wi:', '');
     if (repoId && this._issues.has(repoId)) {
-      return this._issues.get(repoId)!.map((i) => this.buildIssueItem(i));
+      return this.applyRuntimeFilter(this._issues.get(repoId)!).map((i) => this.buildIssueItem(i));
     }
 
     return [];
@@ -202,8 +290,29 @@ export class WorkItemsTreeProvider implements vscode.TreeDataProvider<WorkItemsT
     });
   }
 
-  private buildMilestoneGroups(): WorkItemsTreeItem[] | undefined {
-    const allIssues = [...this._issues.values()].flat();
+  private applyRuntimeFilter(issues: GitHubIssue[]): GitHubIssue[] {
+    if (!this.isFiltered) return issues;
+    return issues.filter(issue => {
+      if (this._filter.repos.length > 0 && !this._filter.repos.includes(issue.repository)) return false;
+      if (this._filter.labels.length > 0 && !issue.labels.some(l => this._filter.labels.includes(l))) return false;
+      if (this._filter.states.length > 0 && !this._filter.states.includes(mapGitHubState(issue))) return false;
+      return true;
+    });
+  }
+
+  private applyAdoRuntimeFilter(items: AdoWorkItem[]): AdoWorkItem[] {
+    if (!this.isFiltered) return items;
+    return items.filter(wi => {
+      if (this._filter.repos.length > 0 && !this._filter.repos.includes('(ADO)')) return false;
+      if (this._filter.labels.length > 0 && !wi.tags.some(t => this._filter.labels.includes(t))) return false;
+      if (this._filter.states.length > 0 && !this._filter.states.includes(mapAdoState(wi.state))) return false;
+      return true;
+    });
+  }
+
+  private buildMilestoneGroups(filteredIssues?: Map<string, GitHubIssue[]>): WorkItemsTreeItem[] | undefined {
+    const source = filteredIssues ?? this._issues;
+    const allIssues = [...source.values()].flat();
     const milestones = new Map<string, GitHubIssue[]>();
     const noMilestone: GitHubIssue[] = [];
 


### PR DESCRIPTION
## Summary

Adds interactive filtering to the Work Items tree view. Closes #132.

### How it works

1. Click the **filter funnel** icon in the Work Items toolbar
2. QuickPick shows three filter dimensions: Repos, State, Labels
3. Select any combination of filters
4. Active filters shown in panel description (e.g. `label:bug . state:active`)
5. **Clear** button appears when filters are active

### State mapping (unified across ADO + GitHub)

| Filter | GitHub | ADO |
|---|---|---|
| Open (New) | open + no assignees | New |
| Active / In Progress | open + has assignees | Active, Doing |

### Design decisions

- **Session-scoped** filters (not persisted) - matches VS Code Test Explorer pattern
- **Render-time filtering** - no change to fetch logic
- **GitHub + ADO unified** - same filter applies to both sources

### Files changed

| File | Change |
|---|---|
| `src/work-items-tree.ts` | UnifiedState type, filter state, runtime filter methods, getAllLabels/getAllRepos |
| `src/extension.ts` | Filter QuickPick command, clear command, createTreeView, context key |
| `package.json` | 2 new commands, 3 toolbar buttons, 2 commandPalette entries |
| `src/__tests__/work-items-tree.test.ts` | 14 new tests for state mapping and filtering |
| `src/__tests__/extension-commands.test.ts` | Updated mocks for new provider methods |

454 tests pass (14 new).
