### PR TITLE
feat: replace hardcoded Agency with generic CLI Provider system (#101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
         "category": "EditLess"
       },
       {
-        "command": "editless.updateAgency",
-        "title": "Update Agency CLI",
+        "command": "editless.updateCliProvider",
+        "title": "Update CLI Provider",
         "category": "EditLess",
         "icon": "$(cloud-download)"
       },
@@ -276,7 +276,7 @@
         { "command": "editless.showHiddenAgents", "when": "view == editlessTree", "group": "navigation@2" },
         { "command": "editless.addNew", "when": "view == editlessTree", "group": "navigation@3" },
         { "command": "editless.addSquad", "when": "view == editlessTree", "group": "navigation@4" },
-        { "command": "editless.updateAgency", "when": "view == editlessTree && editless.agencyUpdateAvailable", "group": "1_updates" },
+        { "command": "editless.updateCliProvider", "when": "view == editlessTree && editless.cliUpdateAvailable", "group": "1_updates" },
         { "command": "editless.upgradeAllSquads", "when": "view == editlessTree", "group": "1_updates" },
         { "command": "editless.refreshWorkItems", "when": "view == editlessWorkItems", "group": "navigation@1" },
         { "command": "editless.filterWorkItems", "when": "view == editlessWorkItems", "group": "navigation@2" },
@@ -386,21 +386,33 @@
           "scope": "resource",
           "order": 3
         },
-        "editless.cli.provider": {
-          "type": "string",
-          "default": "copilot",
-          "enum": ["copilot", "agency", "claude", "custom"],
-          "enumDescriptions": [
-            "GitHub Copilot CLI — default, works out of the box",
-            "Agency CLI — auto-detected when installed",
-            "Anthropic Claude CLI",
-            "User-defined CLI — presence-only detection, no version checking"
+        "editless.cli.providers": {
+          "type": "array",
+          "default": [
+            {
+              "name": "Copilot CLI",
+              "command": "copilot",
+              "versionCommand": "copilot --version",
+              "versionRegex": "(\\d+\\.\\d+[\\d.]*)",
+              "launchCommand": "copilot --agent $(agent)",
+              "createCommand": "",
+              "updateCommand": "",
+              "updateRunCommand": "",
+              "upToDatePattern": "up to date"
+            }
           ],
-          "enumItemLabels": ["Copilot", "Agency", "Claude", "Custom"],
-          "description": "CLI provider for agent sessions. Auto-detected on startup.",
-          "markdownDescription": "CLI provider for agent sessions. Auto-detected on startup — only change this if auto-detection picks the wrong provider.\n\nEach provider has built-in support for version checking and updates. Choose **Custom** to use a CLI not listed here.",
+          "description": "CLI providers for agent sessions. Each provider defines how to launch, detect, and update a CLI tool.",
+          "markdownDescription": "CLI providers for agent sessions. Each entry defines a CLI tool with version detection, launch command, and optional update support.\n\nThe first detected provider is used by default (override with `editless.cli.activeProvider`).\n\nCopilot CLI is included by default and will be re-added if removed.",
           "scope": "window",
           "order": 20
+        },
+        "editless.cli.activeProvider": {
+          "type": "string",
+          "default": "auto",
+          "description": "Active CLI provider name, or 'auto' to use the first detected provider.",
+          "markdownDescription": "Active CLI provider. Set to `\"auto\"` (default) to use the first detected provider, or specify a provider name from `editless.cli.providers`.",
+          "scope": "window",
+          "order": 21
         },
         "editless.github.repos": {
           "type": "array",

--- a/src/__tests__/agency-surface-audit.test.ts
+++ b/src/__tests__/agency-surface-audit.test.ts
@@ -3,31 +3,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 /**
- * Guardrail: ensures Agency CLI surface area is limited to an approved allowlist.
- * If this test fails, a new agency reference was added that isn't in the allowlist.
- * Either add it to APPROVED_PATTERNS (with team approval) or remove the reference.
+ * Guardrail: ensures ZERO Agency CLI references exist in non-test source.
+ * Agency was replaced with a generic CLI provider system in #101.
+ * If this test fails, an agency reference was re-introduced — remove it.
  */
 
 const SRC_DIR = path.resolve(__dirname, '..');
-
-// Approved patterns — every line containing "agency" (case-insensitive)
-// in non-test source must match at least one of these.
-const APPROVED_PATTERNS: RegExp[] = [
-  // Approved CLI invocations
-  /agency\s+--version/,
-  /agency\s+update/,
-  /agency\s+copilot/,
-  // String literal: provider name ('agency' or "agency")
-  /['"]agency['"]/,
-  // Capitalized form in user-facing strings / display text
-  /Agency/,
-  // Part of a camelCase/PascalCase identifier (word char adjacent)
-  /\wagency|agency\w/i,
-  // Comment lines (single-line, block, or JSDoc)
-  /^\s*\/\//,
-  /^\s*\*/,
-  /^\s*\/\*/,
-];
 
 function collectSourceFiles(dir: string): string[] {
   const results: string[] = [];
@@ -43,8 +24,8 @@ function collectSourceFiles(dir: string): string[] {
   return results;
 }
 
-describe('Agency CLI surface area audit', () => {
-  it('should only contain approved agency references in non-test source files', () => {
+describe('Agency CLI removal guardrail (#101)', () => {
+  it('should have ZERO agency references in non-test source files', () => {
     const files = collectSourceFiles(SRC_DIR);
     const violations: string[] = [];
 
@@ -52,29 +33,20 @@ describe('Agency CLI surface area audit', () => {
       const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
-        if (!/agency/i.test(line)) { continue; }
-
-        const approved = APPROVED_PATTERNS.some(p => p.test(line));
-        if (!approved) {
+        // Skip comment-only lines
+        if (/^\s*(\/\/|\/\*|\*)/.test(line)) continue;
+        if (/agency/i.test(line)) {
           const rel = path.relative(SRC_DIR, filePath);
           violations.push(`${rel}:${i + 1}: ${line.trim()}`);
         }
       }
     }
 
-    expect(violations, `Unapproved agency references found:\n${violations.join('\n')}`).toHaveLength(0);
+    expect(violations, `Agency references found:\n${violations.join('\n')}`).toHaveLength(0);
   });
 
   it('should find at least one source file to scan', () => {
     const files = collectSourceFiles(SRC_DIR);
     expect(files.length).toBeGreaterThan(0);
-  });
-
-  it('should find known agency references (sanity check)', () => {
-    const files = collectSourceFiles(SRC_DIR);
-    const allLines = files.flatMap(f => fs.readFileSync(f, 'utf-8').split('\n'));
-    const agencyLines = allLines.filter(l => /agency/i.test(l));
-    // cli-provider.ts alone has many references — expect a healthy count
-    expect(agencyLines.length).toBeGreaterThan(5);
   });
 });

--- a/src/__tests__/cli-provider.test.ts
+++ b/src/__tests__/cli-provider.test.ts
@@ -2,50 +2,71 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type * as vscode from 'vscode';
 
 // ---------------------------------------------------------------------------
-// Hoisted mocks — available before vi.mock factories execute
+// Hoisted mocks
 // ---------------------------------------------------------------------------
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
-const { mockExec, mockShowInformationMessage, mockWithProgress, mockShowErrorMessage, mockExecuteCommand } = vi.hoisted(() => ({
+const { mockExec, mockShowInformationMessage, mockWithProgress, mockShowErrorMessage, mockExecuteCommand, mockConfigGet, mockConfigUpdate, mockShowQuickPick, mockShowWarningMessage } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockShowInformationMessage: vi.fn().mockResolvedValue(undefined as string | undefined),
   mockWithProgress: vi.fn(),
   mockShowErrorMessage: vi.fn(),
   mockExecuteCommand: vi.fn(),
+  mockConfigGet: vi.fn(),
+  mockConfigUpdate: vi.fn().mockResolvedValue(undefined),
+  mockShowQuickPick: vi.fn(),
+  mockShowWarningMessage: vi.fn(),
 }));
 
 vi.mock('child_process', () => ({
   exec: mockExec,
 }));
 
+vi.mock('../notifications', () => ({
+  isNotificationEnabled: () => true,
+}));
+
 vi.mock('vscode', () => ({
   workspace: {
     getConfiguration: () => ({
-      get: (_key: string, defaultValue?: string) => defaultValue,
+      get: mockConfigGet,
+      update: mockConfigUpdate,
     }),
   },
   window: {
     showInformationMessage: mockShowInformationMessage,
     showErrorMessage: mockShowErrorMessage,
+    showWarningMessage: mockShowWarningMessage,
+    showQuickPick: mockShowQuickPick,
     withProgress: mockWithProgress,
   },
   commands: {
+    registerCommand: vi.fn((_id: string, handler: Function) => {
+      (registerCommand as any).lastHandler = handler;
+      return { dispose: vi.fn() };
+    }),
     executeCommand: mockExecuteCommand,
   },
   ProgressLocation: { Notification: 15 },
+  ConfigurationTarget: { Global: 1 },
 }));
 
-import { probeAllProviders, checkAgencyOnStartup, checkProviderUpdatesOnStartup, getAllProviders } from '../cli-provider';
+const registerCommand = vi.fn();
+
+import {
+  probeAllProviders,
+  resolveActiveProvider,
+  getActiveCliProvider,
+  getActiveProviderLaunchCommand,
+  getAllProviders,
+  checkProviderUpdatesOnStartup,
+  registerCliUpdateCommand,
+} from '../cli-provider';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-interface AgencyPromptCache {
-  promptedVersion: string;
-  timestamp: number;
-}
 
 function makeContext(data: Record<string, unknown> = {}): vscode.ExtensionContext {
   const store = new Map<string, unknown>(Object.entries(data));
@@ -64,337 +85,203 @@ function makeContext(data: Record<string, unknown> = {}): vscode.ExtensionContex
   } as unknown as vscode.ExtensionContext;
 }
 
-async function setupAgencyDetected(version: string): Promise<void> {
+function mockConfigWithProviders(providers: unknown[], activeProvider = 'auto'): void {
+  mockConfigGet.mockImplementation((key: string) => {
+    if (key === 'cli.providers') return providers;
+    if (key === 'cli.activeProvider') return activeProvider;
+    return undefined;
+  });
+}
+
+function setupCopilotDetected(version = '2.0.0'): void {
   mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
     if (typeof opts === 'function') { cb = opts as ExecCallback; }
     if (!cb) return;
-    if (cmd === 'agency --version') { cb(null, version, ''); return; }
+    if (cmd === 'copilot --version') { cb(null, version, ''); return; }
     cb(new Error('not found'), '', '');
   });
-  await probeAllProviders();
 }
 
-async function setupNoProvidersDetected(): Promise<void> {
+function setupNoProvidersDetected(): void {
   mockExec.mockImplementation((_cmd: string, opts: unknown, cb?: ExecCallback) => {
     if (typeof opts === 'function') { cb = opts as ExecCallback; }
     if (cb) cb(new Error('not found'), '', '');
   });
-  await probeAllProviders();
-}
-
-function mockExecForUpdates(stdout: string, fail = false): void {
-  mockExec.mockImplementation(
-    (cmd: string, opts: unknown, cb?: ExecCallback) => {
-      if (typeof opts === 'function') { cb = opts as ExecCallback; }
-      if (!cb) return;
-      // Probe calls (version commands) — keep returning detected versions
-      if (cmd.includes('--version')) {
-        if (cmd === 'agency --version') { cb(null, '1.0.0', ''); return; }
-        if (cmd === 'copilot --version') { cb(null, '2.0.0', ''); return; }
-        if (cmd === 'claude --version') { cb(null, '3.0.0', ''); return; }
-        cb(new Error('not found'), '', ''); return;
-      }
-      // Update commands
-      if (fail) { cb(new Error('command failed'), '', 'error output'); return; }
-      cb(null, stdout, '');
-    },
-  );
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('checkAgencyOnStartup', () => {
+describe('cli-provider (generic)', () => {
   beforeEach(() => {
     mockExec.mockReset();
     mockShowInformationMessage.mockReset();
     mockShowInformationMessage.mockResolvedValue(undefined as string | undefined);
     mockExecuteCommand.mockReset();
+    mockConfigGet.mockReset();
+    mockConfigUpdate.mockReset();
+    mockConfigUpdate.mockResolvedValue(undefined);
   });
 
-  it('should not show toast when agency is not detected', async () => {
-    await setupNoProvidersDetected();
+  describe('probeAllProviders', () => {
+    it('should self-heal by adding Copilot default when providers array is empty', async () => {
+      mockConfigWithProviders([]);
+      setupCopilotDetected();
 
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-  });
-
-  it('should not show toast when agency version is empty', async () => {
-    mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
-      if (typeof opts === 'function') { cb = opts as ExecCallback; }
-      if (!cb) return;
-      if (cmd === 'agency --version') { cb(null, '', ''); return; }
-      cb(new Error('not found'), '', '');
-    });
-    await probeAllProviders();
-
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-  });
-
-  it('should not show toast when cached within 24h for same version', async () => {
-    await setupAgencyDetected('1.2.3');
-    const context = makeContext({
-      'editless.agencyUpdatePrompt': {
-        promptedVersion: '1.2.3',
-        timestamp: Date.now() - 1_000,
-      } satisfies AgencyPromptCache,
+      await probeAllProviders();
+      // Self-healing should trigger config.update
+      expect(mockConfigUpdate).toHaveBeenCalled();
+      const providers = getAllProviders();
+      expect(providers.some(p => p.name === 'Copilot CLI')).toBe(true);
     });
 
-    checkAgencyOnStartup(context);
+    it('should not self-heal when Copilot provider already exists', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ]);
+      setupCopilotDetected();
 
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-  });
-
-  it('should show toast when no cache exists and update is available', async () => {
-    await setupAgencyDetected('1.2.3');
-    mockExecForUpdates('Agency 1.3.0 is available');
-
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Agency CLI update available'),
-      'Update',
-    );
-  });
-
-  it('should show toast when cache expired (>24h)', async () => {
-    await setupAgencyDetected('1.2.3');
-    mockExecForUpdates('Agency 1.3.0 is available');
-    const context = makeContext({
-      'editless.agencyUpdatePrompt': {
-        promptedVersion: '1.2.3',
-        timestamp: Date.now() - 25 * 60 * 60 * 1_000,
-      } satisfies AgencyPromptCache,
+      await probeAllProviders();
+      expect(mockConfigUpdate).not.toHaveBeenCalled();
     });
 
-    checkAgencyOnStartup(context);
+    it('should detect provider when version command succeeds', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ]);
+      setupCopilotDetected('3.5.1');
 
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Agency CLI update available'),
-      'Update',
-    );
-  });
-
-  it('should show toast when version changed since last prompt', async () => {
-    await setupAgencyDetected('2.0.0');
-    mockExecForUpdates('Agency 2.1.0 is available');
-    const context = makeContext({
-      'editless.agencyUpdatePrompt': {
-        promptedVersion: '1.2.3',
-        timestamp: Date.now() - 1_000,
-      } satisfies AgencyPromptCache,
+      const providers = await probeAllProviders();
+      expect(providers[0].detected).toBe(true);
+      expect(providers[0].version).toBe('3.5.1');
     });
 
-    checkAgencyOnStartup(context);
+    it('should not detect provider when version command fails', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ]);
+      setupNoProvidersDetected();
 
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Agency CLI update available'),
-      'Update',
-    );
-  });
+      const providers = await probeAllProviders();
+      expect(providers[0].detected).toBe(false);
+    });
 
-  it('should not show toast when agency update reports up to date', async () => {
-    await setupAgencyDetected('1.2.3');
-    mockExecForUpdates('Everything is up to date');
-
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-  });
-
-  it('should not show toast when exec errors (best-effort, silent)', async () => {
-    await setupAgencyDetected('1.2.3');
-    mockExecForUpdates('', true);
-
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-  });
-
-  it('should record prompt in globalState when showing toast', async () => {
-    await setupAgencyDetected('1.2.3');
-    mockExecForUpdates('Agency 1.3.0 is available');
-    const context = makeContext();
-
-    checkAgencyOnStartup(context);
-
-    const cached = context.globalState.get<AgencyPromptCache>('editless.agencyUpdatePrompt');
-    expect(cached).toBeDefined();
-    expect(cached!.promptedVersion).toBe('1.2.3');
-    expect(cached!.timestamp).toBeLessThanOrEqual(Date.now());
-    expect(cached!.timestamp).toBeGreaterThan(Date.now() - 5_000);
-  });
-
-  it('should not block — returns before exec callback fires', async () => {
-    await setupAgencyDetected('1.2.3');
-    let capturedCallback: ExecCallback | undefined;
-    mockExec.mockImplementation(
-      (cmd: string, opts: unknown, cb?: ExecCallback) => {
+    it('should use custom versionRegex for version parsing', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+        { name: 'Custom', command: 'custom', versionCommand: 'custom version', versionRegex: 'v(\\d+\\.\\d+)' },
+      ]);
+      mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
         if (typeof opts === 'function') { cb = opts as ExecCallback; }
         if (!cb) return;
-        if (cmd.includes('--version')) { cb(new Error('not found'), '', ''); return; }
-        capturedCallback = cb;
-      },
-    );
+        if (cmd === 'custom version') { cb(null, 'Custom CLI v4.2 stable', ''); return; }
+        cb(new Error('not found'), '', '');
+      });
 
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).not.toHaveBeenCalled();
-
-    capturedCallback!(null, 'Agency 1.3.0 is available', '');
-    expect(mockShowInformationMessage).toHaveBeenCalled();
-  });
-
-  it('should include current version in toast message', async () => {
-    await setupAgencyDetected('3.5.7');
-    mockExecForUpdates('Agency 4.0.0 is available');
-
-    checkAgencyOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('3.5.7'),
-      'Update',
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Generalized provider update infrastructure (#14)
-// ---------------------------------------------------------------------------
-
-describe('checkProviderUpdatesOnStartup — generalized provider updates', () => {
-  beforeEach(() => {
-    mockExec.mockReset();
-    mockShowInformationMessage.mockReset();
-    mockShowInformationMessage.mockResolvedValue(undefined as string | undefined);
-    mockWithProgress.mockReset();
-    mockShowErrorMessage.mockReset();
-    mockExecuteCommand.mockReset();
-  });
-
-  async function setupAllProvidersDetected(): Promise<void> {
-    mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
-      if (typeof opts === 'function') { cb = opts as ExecCallback; }
-      if (!cb) return;
-      if (cmd === 'agency --version') { cb(null, '1.0.0', ''); return; }
-      if (cmd === 'copilot --version') { cb(null, '2.0.0', ''); return; }
-      if (cmd === 'claude --version') { cb(null, '3.0.0', ''); return; }
-      cb(new Error('not found'), '', '');
+      const providers = await probeAllProviders();
+      const custom = providers.find(p => p.name === 'Custom');
+      expect(custom?.version).toBe('4.2');
     });
-    await probeAllProviders();
-  }
-
-  it('should skip providers without updateCommand', async () => {
-    await setupAllProvidersDetected();
-    mockExecForUpdates('New version available');
-
-    checkProviderUpdatesOnStartup(makeContext());
-
-    // Only agency has updateCommand — filter out version probe calls
-    const updateCalls = mockExec.mock.calls.filter(
-      (c: unknown[]) => !(c[0] as string).includes('--version'),
-    );
-    expect(updateCalls).toHaveLength(1);
-    expect(updateCalls[0][0]).toBe('agency update');
   });
 
-  it('should check all providers with updateCommand set', async () => {
-    await setupAllProvidersDetected();
-    const copilot = getAllProviders().find(p => p.name === 'copilot')!;
-    copilot.updateCommand = 'copilot update';
-    copilot.upToDatePattern = 'already current';
+  describe('resolveActiveProvider', () => {
+    it('should resolve to first detected provider when set to auto', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ], 'auto');
+      setupCopilotDetected();
+      await probeAllProviders();
 
-    mockExecForUpdates('New version available');
-
-    checkProviderUpdatesOnStartup(makeContext());
-
-    const updateCalls = mockExec.mock.calls.filter(
-      (c: unknown[]) => !(c[0] as string).includes('--version'),
-    );
-    expect(updateCalls).toHaveLength(2);
-    expect(updateCalls.map((c: unknown[]) => c[0])).toContain('agency update');
-    expect(updateCalls.map((c: unknown[]) => c[0])).toContain('copilot update');
-  });
-
-  it('should isolate cache per provider', async () => {
-    await setupAllProvidersDetected();
-    const copilot = getAllProviders().find(p => p.name === 'copilot')!;
-    copilot.updateCommand = 'copilot update';
-
-    const context = makeContext({
-      'editless.agencyUpdatePrompt': {
-        promptedVersion: '1.0.0',
-        timestamp: Date.now() - 1_000,
-      },
+      const active = resolveActiveProvider();
+      expect(active?.name).toBe('Copilot CLI');
     });
 
-    mockExecForUpdates('New version available');
+    it('should resolve to named provider when explicitly configured', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+        { name: 'Custom', command: 'custom', versionCommand: 'custom --version' },
+      ], 'Custom');
+      mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
+        if (typeof opts === 'function') { cb = opts as ExecCallback; }
+        if (!cb) return;
+        if (cmd === 'copilot --version') { cb(null, '2.0.0', ''); return; }
+        if (cmd === 'custom --version') { cb(null, '1.0.0', ''); return; }
+        cb(new Error('not found'), '', '');
+      });
+      await probeAllProviders();
 
-    checkProviderUpdatesOnStartup(context);
-
-    // Agency cached and skipped; copilot has no cache and gets checked
-    const updateCalls = mockExec.mock.calls.filter(
-      (c: unknown[]) => !(c[0] as string).includes('--version'),
-    );
-    expect(updateCalls).toHaveLength(1);
-    expect(updateCalls[0][0]).toBe('copilot update');
-  });
-
-  it('should include provider display name in toast message', async () => {
-    await setupAgencyDetected('1.0.0');
-    mockExecForUpdates('New version available');
-
-    checkProviderUpdatesOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Agency CLI update available'),
-      'Update',
-    );
-  });
-
-  it('should use default pattern when upToDatePattern is undefined', async () => {
-    await setupAgencyDetected('1.0.0');
-    const agency = getAllProviders().find(p => p.name === 'agency')!;
-    agency.upToDatePattern = undefined;
-
-    mockExecForUpdates('version 2.0.0 available for download');
-
-    checkProviderUpdatesOnStartup(makeContext());
-
-    expect(mockShowInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Agency CLI update available'),
-      'Update',
-    );
-  });
-
-  it('should use updateRunCommand when user clicks Update', async () => {
-    await setupAgencyDetected('1.0.0');
-    const agency = getAllProviders().find(p => p.name === 'agency')!;
-    agency.updateRunCommand = 'agency update --force';
-
-    mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
-      if (typeof opts === 'function') { cb = opts as ExecCallback; }
-      if (!cb) return;
-      if (cmd.includes('--version')) { cb(new Error('not found'), '', ''); return; }
-      cb(null, 'version 2.0.0 available', '');
+      const active = resolveActiveProvider();
+      expect(active?.name).toBe('Custom');
     });
-    mockShowInformationMessage.mockResolvedValue('Update');
-    mockWithProgress.mockImplementation(
-      (_opts: unknown, task: () => Promise<void>) => task(),
-    );
 
-    checkProviderUpdatesOnStartup(makeContext());
+    it('should fall back to first detected when named provider is not found', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ], 'NonExistent');
+      setupCopilotDetected();
+      await probeAllProviders();
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+      const active = resolveActiveProvider();
+      expect(active?.name).toBe('Copilot CLI');
+    });
+  });
 
-    const updateCalls = mockExec.mock.calls.filter(
-      (c: unknown[]) => !(c[0] as string).includes('--version'),
-    );
-    expect(updateCalls).toHaveLength(2);
-    expect(updateCalls[1][0]).toBe('agency update --force');
+  describe('getActiveProviderLaunchCommand', () => {
+    it('should return launch command from active provider', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version', launchCommand: 'copilot --agent $(agent)' },
+      ]);
+      setupCopilotDetected();
+      await probeAllProviders();
+      resolveActiveProvider();
+
+      expect(getActiveProviderLaunchCommand()).toBe('copilot --agent $(agent)');
+    });
+
+    it('should return empty string when no active provider', async () => {
+      mockConfigWithProviders([]);
+      setupNoProvidersDetected();
+      await probeAllProviders();
+      resolveActiveProvider();
+
+      expect(getActiveProviderLaunchCommand()).toBe('');
+    });
+  });
+
+  describe('checkProviderUpdatesOnStartup', () => {
+    it('should not check providers without updateCommand', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version' },
+      ]);
+      setupCopilotDetected();
+      await probeAllProviders();
+
+      mockExec.mockClear();
+      checkProviderUpdatesOnStartup(makeContext());
+      // No update exec calls should be made
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it('should check provider with updateCommand', async () => {
+      mockConfigWithProviders([
+        { name: 'Copilot CLI', command: 'copilot', versionCommand: 'copilot --version', updateCommand: 'copilot update --check' },
+      ]);
+      setupCopilotDetected();
+      await probeAllProviders();
+
+      mockExec.mockImplementation((cmd: string, opts: unknown, cb?: ExecCallback) => {
+        if (typeof opts === 'function') { cb = opts as ExecCallback; }
+        if (!cb) return;
+        cb(null, 'up to date', '');
+      });
+
+      checkProviderUpdatesOnStartup(makeContext());
+      expect(mockExec).toHaveBeenCalledWith(
+        'copilot update --check',
+        expect.anything(),
+        expect.any(Function),
+      );
+    });
   });
 });

--- a/src/__tests__/discovery.test.ts
+++ b/src/__tests__/discovery.test.ts
@@ -21,6 +21,10 @@ vi.mock('vscode', () => ({
   },
 }));
 
+vi.mock('../cli-provider', () => ({
+  getActiveProviderLaunchCommand: () => 'copilot --agent $(agent)',
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -228,7 +232,7 @@ describe('discoverAgentTeams', () => {
 
     const result = discoverAgentTeams(tmpDir, []);
     
-    expect(result[0].launchCommand).toBe('agency copilot --agent squad --yolo -s');
+    expect(result[0].launchCommand).toBe('copilot --agent $(agent)');
   });
 
   describe('edge cases', () => {

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -274,7 +274,7 @@ vi.mock('../squad-upgrader', () => ({
 }));
 
 vi.mock('../cli-provider', () => ({
-  registerAgencyUpdateCommand: vi.fn(() => ({ dispose: vi.fn() })),
+  registerCliUpdateCommand: vi.fn(() => ({ dispose: vi.fn() })),
   checkProviderUpdatesOnStartup: vi.fn(),
   probeAllProviders: vi.fn(() => Promise.resolve()),
   resolveActiveProvider: vi.fn(),
@@ -381,7 +381,7 @@ function makeSquad(overrides: Record<string, unknown> = {}) {
     icon: '🚀',
     universe: 'test',
     path: '/squads/alpha',
-    launchCommand: 'agency copilot --model gpt-5',
+    launchCommand: 'copilot --agent squad --model gpt-5',
     ...overrides,
   };
 }
@@ -928,14 +928,14 @@ describe('extension command handlers', () => {
   describe('editless.changeModel', () => {
     it('should update launch command model and refresh tree', async () => {
       const item = new MockEditlessTreeItem('Alpha', 'squad', 0, 'squad-1');
-      const squad = makeSquad({ launchCommand: 'agency copilot --model gpt-5' });
+      const squad = makeSquad({ launchCommand: 'copilot --agent squad --model gpt-5' });
       mockGetSquad.mockReturnValue(squad);
       mockShowQuickPick.mockResolvedValue({ label: 'claude-sonnet-4' });
 
       await getHandler('editless.changeModel')(item);
 
       expect(mockUpdateSquad).toHaveBeenCalledWith('squad-1', {
-        launchCommand: 'agency copilot --model claude-sonnet-4',
+        launchCommand: 'copilot --agent squad --model claude-sonnet-4',
       });
       expect(mockTreeRefresh).toHaveBeenCalled();
     });
@@ -964,7 +964,7 @@ describe('extension command handlers', () => {
 
     it('should no-op when selected model is same as current', async () => {
       const item = new MockEditlessTreeItem('Alpha', 'squad', 0, 'squad-1');
-      mockGetSquad.mockReturnValue(makeSquad({ launchCommand: 'agency copilot --model gpt-5' }));
+      mockGetSquad.mockReturnValue(makeSquad({ launchCommand: 'copilot --agent squad --model gpt-5' }));
       mockShowQuickPick.mockResolvedValue({ label: 'gpt-5' });
 
       await getHandler('editless.changeModel')(item);
@@ -973,13 +973,13 @@ describe('extension command handlers', () => {
 
     it('should append --model when launch command has no model flag', async () => {
       const item = new MockEditlessTreeItem('Alpha', 'squad', 0, 'squad-1');
-      mockGetSquad.mockReturnValue(makeSquad({ launchCommand: 'agency copilot' }));
+      mockGetSquad.mockReturnValue(makeSquad({ launchCommand: 'copilot --agent squad' }));
       mockShowQuickPick.mockResolvedValue({ label: 'claude-sonnet-4' });
 
       await getHandler('editless.changeModel')(item);
 
       expect(mockUpdateSquad).toHaveBeenCalledWith('squad-1', {
-        launchCommand: 'agency copilot --model claude-sonnet-4',
+        launchCommand: 'copilot --agent squad --model claude-sonnet-4',
       });
     });
   });

--- a/src/__tests__/terminal-manager.test.ts
+++ b/src/__tests__/terminal-manager.test.ts
@@ -50,6 +50,10 @@ vi.mock('vscode', () => ({
   },
 }));
 
+vi.mock('../cli-provider', () => ({
+  getActiveProviderLaunchCommand: () => '',
+}));
+
 import { TerminalManager, type PersistedTerminalInfo } from '../terminal-manager';
 
 function makeMockTerminal(name: string): vscode.Terminal {
@@ -1300,27 +1304,27 @@ describe('TerminalManager', () => {
     it('should persist launchCommand from squad config', () => {
       const ctx = makeMockContext();
       const mgr = new TerminalManager(ctx);
-      const config = makeSquadConfig({ launchCommand: 'agency copilot --agent squad' });
+      const config = makeSquadConfig({ launchCommand: 'copilot --agent squad' });
 
       mgr.launchTerminal(config);
 
       const persisted = getLastPersistedState(ctx);
       expect(persisted).toBeDefined();
-      expect(persisted![0].launchCommand).toBe('agency copilot --agent squad');
+      expect(persisted![0].launchCommand).toBe('copilot --agent squad');
     });
 
     it('should restore launchCommand after reconciliation', () => {
       const liveTerminal = makeMockTerminal('🧪 Test Squad #1');
       mockTerminals.push(liveTerminal);
 
-      const saved = [makePersistedEntry({ launchCommand: 'agency copilot --yolo' })];
+      const saved = [makePersistedEntry({ launchCommand: 'copilot --agent squad' })];
       const ctx = makeMockContext(saved);
       const mgr = new TerminalManager(ctx);
 
       mgr.reconcile();
 
       const info = mgr.getTerminalInfo(liveTerminal);
-      expect(info?.launchCommand).toBe('agency copilot --yolo');
+      expect(info?.launchCommand).toBe('copilot --agent squad');
     });
   });
 
@@ -1330,7 +1334,7 @@ describe('TerminalManager', () => {
         id: 'relaunch-cmd-1',
         terminalName: '🧪 No Match',
         displayName: '🧪 Test Squad #1',
-        launchCommand: 'agency copilot --agent squad',
+        launchCommand: 'copilot --agent squad',
       });
       const ctx = makeMockContext([orphanEntry]);
       const mgr = new TerminalManager(ctx);
@@ -1338,7 +1342,7 @@ describe('TerminalManager', () => {
 
       const terminal = mgr.relaunchSession(orphanEntry);
 
-      expect(terminal.sendText).toHaveBeenCalledWith('agency copilot --agent squad');
+      expect(terminal.sendText).toHaveBeenCalledWith('copilot --agent squad');
     });
 
     it('should send resume command with agentSessionId when available', () => {
@@ -1346,7 +1350,7 @@ describe('TerminalManager', () => {
         id: 'relaunch-resume-1',
         terminalName: '🧪 No Match',
         displayName: '🧪 Test Squad #1',
-        launchCommand: 'agency copilot --agent squad',
+        launchCommand: 'copilot --agent squad',
         agentSessionId: 'session-to-resume',
       });
       const ctx = makeMockContext([orphanEntry]);
@@ -1356,7 +1360,7 @@ describe('TerminalManager', () => {
       const terminal = mgr.relaunchSession(orphanEntry);
 
       expect(terminal.sendText).toHaveBeenCalledWith(
-        'agency copilot --agent squad --resume session-to-resume',
+        'copilot --agent squad --resume session-to-resume',
       );
     });
 
@@ -1380,7 +1384,7 @@ describe('TerminalManager', () => {
         id: 'relaunch-preserve-1',
         terminalName: '🧪 No Match',
         displayName: '🧪 Test Squad #1',
-        launchCommand: 'agency copilot',
+        launchCommand: 'copilot --agent squad',
         agentSessionId: 'preserved-session',
       });
       const ctx = makeMockContext([orphanEntry]);
@@ -1391,7 +1395,7 @@ describe('TerminalManager', () => {
 
       const info = mgr.getTerminalInfo(terminal);
       expect(info?.agentSessionId).toBe('preserved-session');
-      expect(info?.launchCommand).toBe('agency copilot');
+      expect(info?.launchCommand).toBe('copilot --agent squad');
     });
   });
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { AgentTeamConfig } from './types';
 import { EditlessRegistry } from './registry';
 import { resolveTeamMd } from './team-dir';
+import { getActiveProviderLaunchCommand } from './cli-provider';
 
 const TEAM_ROSTER_PREFIX = /^team\s+roster\s*[—\-:]\s*(.+)$/i;
 
@@ -89,7 +90,7 @@ export function discoverAgentTeams(dirPath: string, existingSquads: AgentTeamCon
       path: folderPath,
       icon: '🔷',
       universe: parsed.universe,
-      launchCommand: 'agency copilot --agent squad --yolo -s',
+      launchCommand: getActiveProviderLaunchCommand(),
     });
   }
 
@@ -137,7 +138,7 @@ export function discoverAgentTeamsInMultiplePaths(
         path: folderPath,
         icon: '🔷',
         universe: parsed.universe,
-        launchCommand: 'agency copilot --agent squad --yolo -s',
+        launchCommand: getActiveProviderLaunchCommand(),
       });
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { EditlessTreeProvider, EditlessTreeItem } from './editless-tree';
 import { TerminalManager } from './terminal-manager';
 import { SessionLabelManager, promptClearLabel } from './session-labels';
 import { registerSquadUpgradeCommand, registerSquadUpgradeAllCommand, checkSquadUpgradesOnStartup, clearLatestVersionCache } from './squad-upgrader';
-import { registerAgencyUpdateCommand, checkProviderUpdatesOnStartup, probeAllProviders, resolveActiveProvider } from './cli-provider';
+import { registerCliUpdateCommand, checkProviderUpdatesOnStartup, probeAllProviders, resolveActiveProvider } from './cli-provider';
 import { registerDiscoveryCommand, checkDiscoveryOnStartup } from './discovery';
 import { discoverAllAgents } from './agent-discovery';
 import { AgentVisibilityManager } from './visibility';
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   context.subscriptions.push(output);
 
   // --- CLI provider detection (async, non-blocking) -------------------------
-  vscode.commands.executeCommand('setContext', 'editless.agencyUpdateAvailable', false);
+  vscode.commands.executeCommand('setContext', 'editless.cliUpdateAvailable', false);
   probeAllProviders().then(() => resolveActiveProvider());
 
   // --- Squad UI integration (#38) ------------------------------------------
@@ -190,8 +190,8 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   context.subscriptions.push(registerSquadUpgradeCommand(context, registry, onUpgradeComplete));
   context.subscriptions.push(registerSquadUpgradeAllCommand(context, registry, onUpgradeComplete));
 
-  // Agency update command
-  context.subscriptions.push(registerAgencyUpdateCommand(context));
+  // CLI provider update command
+  context.subscriptions.push(registerCliUpdateCommand(context));
 
   // Check for CLI provider updates on startup
   checkProviderUpdatesOnStartup(context);

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import type { AgentTeamConfig } from './types';
 import type { SessionContextResolver } from './session-context';
+import { getActiveProviderLaunchCommand } from './cli-provider';
 
 // ---------------------------------------------------------------------------
 // Terminal tracking metadata
@@ -102,7 +103,7 @@ export class TerminalManager implements vscode.Disposable {
       cwd: config.path,
     });
 
-    terminal.sendText(config.launchCommand || 'agency copilot --agent squad --yolo -s');
+    terminal.sendText(config.launchCommand || getActiveProviderLaunchCommand());
     terminal.show();
 
     this._terminals.set(terminal, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface AgentTeamConfig {
   terminalProfileGuid?: string;
   /** Windows Terminal profile name for matching */
   terminalProfileName?: string;
-  /** Command to launch in terminal (e.g., "agency copilot --agent squad ...") */
+  /** Command to launch in terminal (e.g., "copilot --agent squad") */
   launchCommand?: string;
 }
 


### PR DESCRIPTION
## Summary

Replaces all hardcoded Agency CLI support with a generic, user-configurable CLI Provider system. Closes #101.

### Breaking changes

- `editless.cli.provider` (enum) replaced by `editless.cli.providers` (array) + `editless.cli.activeProvider`
- `editless.updateAgency` command replaced by `editless.updateCliProvider`
- `editless.agencyUpdateAvailable` context key replaced by `editless.cliUpdateAvailable`

### New settings

`editless.cli.providers` — array of provider objects:
- name, command, versionCommand, versionRegex, launchCommand, createCommand, updateCommand, updateRunCommand, upToDatePattern

`editless.cli.activeProvider` — `"auto"` (default) or a provider name

### Key features

- **Self-healing:** Copilot CLI default is re-added if removed from settings
- **Custom regex:** versionRegex and upToDatePattern both support regex
- **Multi-provider updates:** Dropdown when multiple providers have updates
- **Zero Agency references:** Guardrail test ensures Agency never creeps back

### Files changed (11)

| File | Change |
|---|---|
| `src/cli-provider.ts` | Complete rewrite: settings-based loading, self-healing, regex matching |
| `src/extension.ts` | Swap imports and context keys |
| `src/discovery.ts` | Use `getActiveProviderLaunchCommand()` |
| `src/terminal-manager.ts` | Use `getActiveProviderLaunchCommand()` fallback |
| `src/types.ts` | Update comment |
| `package.json` | New settings schema, new command |
| 5 test files | Rewritten for generic providers, zero Agency test data |

448 tests pass (12 new generic provider tests).
