### PR TITLE
feat: unified Add flow with Session option and provider-aware agent creation (#125)

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
         { "command": "editless.refresh", "when": "view == editlessTree", "group": "navigation@1" },
         { "command": "editless.showHiddenAgents", "when": "view == editlessTree", "group": "navigation@2" },
         { "command": "editless.addNew", "when": "view == editlessTree", "group": "navigation@3" },
-        { "command": "editless.addSquad", "when": "view == editlessTree", "group": "navigation@4" },
         { "command": "editless.updateCliProvider", "when": "view == editlessTree && editless.cliUpdateAvailable", "group": "1_updates" },
         { "command": "editless.upgradeAllSquads", "when": "view == editlessTree", "group": "1_updates" },
         { "command": "editless.refreshWorkItems", "when": "view == editlessWorkItems", "group": "navigation@1" },


### PR DESCRIPTION
## Changes

### Phase 1 — Remove duplicate toolbar button + add Session option
- Removed \ddSquad\ from \iew/title navigation@4\ in package.json (duplicate folder+ icon)
- Added **Session** option to \ddNew\ QuickPick — delegates to \ditless.launchSession\ which already handles squad picker and terminal creation

### Phase 2 — Provider-aware agent creation  
- When active CLI provider has a \createCommand\, shows mode picker: provider CLI vs repo template
- Provider path substitutes \\\ and \\\ in the \createCommand\ string
- When no provider has \createCommand\, skips picker and goes straight to repo template (no UX change)
- Guards \gentCreationCommand\ config.get() with \	ypeof\ check for mock safety

### Tests (9 new)
- addNew: 5 tests (3 options shown, each delegates correctly, cancel does nothing)
- addAgent: 4 tests (no workspace warning, skip mode picker, show mode picker, cancel name input)

**457 tests passing, lint clean.**

Closes #125