### PR TITLE
docs(ai-team): add CI gate enforcement directive

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -165,6 +165,15 @@ The squad upgrader (`squad-upgrader.ts`) follows this same principle — it beco
 **Why:** We now have real CI gates (lint, build, test, integration). Direct merges bypass them. This ensures every change passes gates before hitting master. Draft PRs aren't needed — it's just Casey, so the draft→publish step adds no value. The `--auto` flag makes routine work zero-friction while still gated.
 **Supersedes:** The "all PRs start as drafts" convention is retired for this project.
 
+### 2026-02-16: NEVER merge PRs with failing CI — verify checks before merge
+**By:** Casey Irvine (user directive)
+**What:** Agents MUST verify CI checks pass before merging any PR. Branch protection is not available on this private repo, so enforcement is manual. Rules:
+1. **Always use `gh pr merge --auto --squash`** — never `gh pr merge --squash` alone. The `--auto` flag waits for required checks to pass before merging.
+2. **If CI fails, fix it first.** Do not merge. Push fixes, wait for CI to go green, then merge (or let `--auto` handle it).
+3. **Before merging manually** (without `--auto`), run `gh pr checks {number} --watch` and confirm all checks pass.
+4. **Never bypass failing checks.** No exceptions. If checks are flaky, fix the flakiness — don't merge around it.
+**Why:** 4 of the last 10 merged PRs had failing CI ("Lint, Build & Test" = FAILURE). This repo has no branch protection enforcement (requires GitHub Pro for private repos), so agents must self-enforce. The `--auto` flag is the primary mechanism — it simply won't merge until checks pass.
+
 ### 2026-02-16: TreeDataProvider must implement getParent() when using reveal()
 **By:** Morty (Extension Dev), issue #95
 **What:** `EditlessTreeProvider` stores a `parent` reference on `EditlessTreeItem`, set during child construction. `getParent(element)` returns `element.parent`. Any code path that constructs tree items for use with `reveal()` (like `findTerminalItem`) must also set the parent reference.


### PR DESCRIPTION
Adds a team directive requiring agents to verify CI checks pass before merging PRs.

**Problem:** 4 of the last 10 merged PRs had failing CI. Branch protection is unavailable on this private repo (requires GitHub Pro), so agents were merging with `gh pr merge --squash` which bypasses checks.

**Fix:** Directive requires `gh pr merge --auto --squash` (waits for checks) and explicitly bans merging with failing CI.

No code changes — team decisions file only.