### PR TITLE
chore: public repo hardening — branch protection, agency audit, doc cleanup

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -165,15 +165,14 @@ The squad upgrader (`squad-upgrader.ts`) follows this same principle — it beco
 **Why:** We now have real CI gates (lint, build, test, integration). Direct merges bypass them. This ensures every change passes gates before hitting master. Draft PRs aren't needed — it's just Casey, so the draft→publish step adds no value. The `--auto` flag makes routine work zero-friction while still gated.
 **Supersedes:** The "all PRs start as drafts" convention is retired for this project.
 
-### 2026-02-16: NEVER merge PRs with failing CI — verify checks before merge
+### 2026-02-16: NEVER merge PRs with failing CI — use --auto --squash
 **By:** Casey Irvine (user directive)
-**What:** Agents MUST verify CI checks pass before merging any PR. Branch protection is not available on this private repo (requires GitHub Pro), and `--auto` merges immediately when no required checks are configured. Enforcement is therefore **procedural**. Rules:
-1. **After creating a PR, wait for CI.** Run `gh pr checks {number} --watch` and wait for ALL checks to pass before proceeding.
-2. **If CI fails, fix it first.** Do not merge. Push fixes to the branch, run `gh pr checks {number} --watch` again, and wait for green.
-3. **Only merge after all checks pass.** Run `gh pr merge {number} --squash` only after step 1 confirms all checks are green.
-4. **Never bypass failing checks.** No exceptions. If checks are flaky, fix the flakiness — don't merge around it.
-5. **The merge command is `gh pr merge {number} --squash`** — do NOT use `--auto` (it merges immediately since no required checks are configured at the repo level).
-**Why:** 4 of the last 10 merged PRs had failing CI ("Lint, Build & Test" = FAILURE). Without branch protection, nothing prevents agents from merging broken code. Agents must self-enforce by watching checks before merging.
+**What:** Agents MUST ensure CI checks pass before merging any PR. Branch protection is now configured on the public repo with required status checks (`Lint, Build & Test`, `VS Code Integration Tests`, `scan`). Rules:
+1. **Always use `gh pr merge {number} --auto --squash`** after creating a PR. The `--auto` flag waits for required checks to pass before merging.
+2. **If CI fails, fix it first.** Push fixes to the branch — `--auto` will re-evaluate and merge when checks go green.
+3. **Never bypass failing checks.** No exceptions. If checks are flaky, fix the flakiness — don't merge around it.
+**Why:** 4 of the last 10 merged PRs (when repo was private) had failing CI. Branch protection with required status checks now enforces this at the platform level. The `--auto` flag is the correct mechanism.
+**Supersedes:** The procedural `gh pr checks --watch` workaround from earlier today (no longer needed — branch protection handles it).
 
 ### 2026-02-16: TreeDataProvider must implement getParent() when using reveal()
 **By:** Morty (Extension Dev), issue #95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Agent tree view with auto-discovery of `.ai-team/` directories
 - Terminal management for AI coding sessions
-- CLI provider system with auto-detection (Copilot, Claude, Agency)
+- CLI provider system with auto-detection (Copilot, Claude, and more)
 - Squad upgrader for Squad CLI teams
 - Status bar with inbox monitoring
 - Session context and labeling

--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -14,4 +14,4 @@ Both tools can coexist. EditLess manages the operational layer (sessions, work i
 
 ## Other Tools
 
-The AI development tools landscape is evolving rapidly. EditLess is designed to be tool-agnostic — it works with any CLI that launches agents (Copilot, Agency, Claude, custom CLIs). As new tools emerge, EditLess aims to integrate with them through its provider system.
+The AI development tools landscape is evolving rapidly. EditLess is designed to be tool-agnostic — it works with any CLI that launches agents (Copilot, Claude, custom CLIs, and more). As new tools emerge, EditLess aims to integrate with them through its provider system.

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -8,10 +8,14 @@ The `master` branch is protected to ensure code quality and prevent accidental b
 
 | Rule | Setting | Description |
 |------|---------|-------------|
-| Required status checks | `build` | The `build` CI job must pass before merging |
+| Required status checks | `Lint, Build & Test`, `VS Code Integration Tests`, `scan` | These CI jobs must pass before merging |
 | Strict status checks | `true` | Branch must be up to date with `master` before merging |
 | Enforce admins | `false` | Admins can bypass protection for emergency hotfixes |
 | Required reviews | `null` | PR reviews are not enforced by branch protection |
+| Required signatures | `false` | Not required — agents cannot sign commits |
+| Required linear history | `false` | Not needed — squash merges keep history clean |
+| Lock branch | `false` | Branch accepts pushes normally |
+| Allow force pushes | `false` | Force pushes to master are blocked |
 | Restrictions | `null` | No push restrictions beyond the above rules |
 
 ## Running the Setup Script

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -14,7 +14,7 @@ All settings are accessible through VS Code's Settings UI (**Ctrl+,**) or direct
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `editless.cli.provider` | `string` | `"copilot"` | CLI provider for agent sessions. Auto-detected on startup. Allowed values: `"copilot"`, `"agency"`, `"claude"`, `"custom"` |
+| `editless.cli.provider` | `string` | `"copilot"` | CLI provider for agent sessions. Auto-detected on startup. Allowed values: `"copilot"`, `"claude"`, `"custom"` |
 ## GitHub Integration
 
 | Setting | Type | Default | Description |

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -13,7 +13,7 @@ gh api -X PUT "repos/$REPO/branches/master/protection" \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["build"]
+    "contexts": ["Lint, Build & Test", "VS Code Integration Tests", "scan"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": null,
@@ -22,5 +22,6 @@ gh api -X PUT "repos/$REPO/branches/master/protection" \
 EOF
 
 echo "✅ Branch protection configured for master"
-echo "  - CI must pass before merge"
+echo "  - Required checks: Lint, Build & Test, VS Code Integration Tests, scan"
 echo "  - Branch must be up to date before merge"
+echo "  - gh pr merge --auto --squash will wait for these checks"


### PR DESCRIPTION
## Summary
Hardens the repo for public visibility.

### Changes
- **Branch protection script** — updated `setup-branch-protection.sh` with correct check names (`Lint, Build & Test`, `VS Code Integration Tests`, `scan`)
- **Agency audit expanded** — now scans all text files in the repo (not just `src/*.ts`), excluding `.ai-team/` and test dirs
- **Agency references removed** — cleaned CHANGELOG.md, docs/ALTERNATIVES.md, docs/SETTINGS.md
- **CI directive updated** — agents use `--auto --squash` now that branch protection enforces required checks
- **BRANCH-PROTECTION.md** — updated to reflect current settings

### Test results
464 tests pass, including the expanded agency audit.