### PR TITLE
fix: batch bug fixes — CLI defaults, roster regex, tree IDs, terminal fullscreen

### DIFF
--- a/src/__tests__/terminal-layout.test.ts
+++ b/src/__tests__/terminal-layout.test.ts
@@ -41,6 +41,7 @@ describe('TerminalLayoutManager', () => {
   let manager: TerminalLayoutManager;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     (vscode.window as unknown as { visibleTextEditors: unknown[] }).visibleTextEditors = [];
     stubSetting(true);
@@ -48,13 +49,16 @@ describe('TerminalLayoutManager', () => {
 
   afterEach(() => {
     manager?.dispose();
+    vi.useRealTimers();
   });
 
   it('should maximize panel when all editors close after opening', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
 
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.toggleMaximizedPanel');
   });
@@ -64,6 +68,7 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([]);
+    vi.advanceTimersByTime(200);
 
     expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
   });
@@ -72,8 +77,11 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([{ document: {} }, { document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
 
     expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
   });
@@ -83,8 +91,10 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     stubSetting(false);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
 
     expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
   });
@@ -93,11 +103,15 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
   });
 
@@ -105,13 +119,17 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
 
     stubSetting(false);
     fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
     stubSetting(false);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
   });
 
@@ -119,7 +137,23 @@ describe('TerminalLayoutManager', () => {
     manager = new TerminalLayoutManager();
 
     fireEditors([]);
+    vi.advanceTimersByTime(200);
     fireEditors([]);
+    vi.advanceTimersByTime(200);
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('should not maximize during rapid tab switches with transient zero state', () => {
+    manager = new TerminalLayoutManager();
+
+    fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
+    // Rapid tab switch: editors briefly go to 0 then back to 1
+    fireEditors([]);
+    vi.advanceTimersByTime(50); // less than debounce
+    fireEditors([{ document: {} }]);
+    vi.advanceTimersByTime(200);
 
     expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
   });

--- a/src/cli-provider.ts
+++ b/src/cli-provider.ts
@@ -19,13 +19,13 @@ export interface CliProvider {
 const COPILOT_DEFAULT: Omit<CliProvider, 'detected' | 'version'> = {
   name: 'Copilot CLI',
   command: 'copilot',
-  versionCommand: 'copilot --version',
+  versionCommand: 'copilot version',
   versionRegex: '(\\d+\\.\\d+[\\d.]*)',
   launchCommand: 'copilot --agent $(agent)',
   createCommand: '',
-  updateCommand: '',
+  updateCommand: 'copilot update',
   updateRunCommand: '',
-  upToDatePattern: 'up to date',
+  upToDatePattern: 'latest version',
 };
 
 let _providers: CliProvider[] = [];

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -363,10 +363,10 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         children = state.roster.map(a => this.buildAgentItem(a, squadId));
         break;
       case 'decisions':
-        children = state.recentDecisions.map(d => this.buildDecisionItem(d));
+        children = state.recentDecisions.map((d, i) => this.buildDecisionItem(d, squadId, i));
         break;
       case 'activity':
-        children = state.recentActivity.map(a => this.buildActivityItem(a));
+        children = state.recentActivity.map((a, i) => this.buildActivityItem(a, squadId, i));
         break;
     }
 
@@ -380,22 +380,25 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   }
 
   private buildAgentItem(agent: AgentInfo, squadId?: string): EditlessTreeItem {
-    const item = new EditlessTreeItem(agent.name, 'agent', vscode.TreeItemCollapsibleState.None, squadId);
+    const item = new EditlessTreeItem(agent.name, 'agent', vscode.TreeItemCollapsibleState.None);
+    item.id = squadId ? `${squadId}:agent:${agent.name}` : undefined;
     item.description = agent.role;
     item.iconPath = new vscode.ThemeIcon('person');
     return item;
   }
 
-  private buildDecisionItem(decision: DecisionEntry): EditlessTreeItem {
+  private buildDecisionItem(decision: DecisionEntry, squadId?: string, index?: number): EditlessTreeItem {
     const item = new EditlessTreeItem(decision.title, 'decision');
+    item.id = squadId ? `${squadId}:decision:${index}` : undefined;
     item.description = `${decision.date} by ${decision.author}`;
     item.iconPath = new vscode.ThemeIcon('law');
     item.tooltip = decision.summary || undefined;
     return item;
   }
 
-  private buildActivityItem(activity: RecentActivity): EditlessTreeItem {
+  private buildActivityItem(activity: RecentActivity, squadId?: string, index?: number): EditlessTreeItem {
     const item = new EditlessTreeItem(`${activity.agent}: ${activity.task}`, 'activity');
+    item.id = squadId ? `${squadId}:activity:${index}` : undefined;
     item.description = activity.outcome;
     item.iconPath = new vscode.ThemeIcon('pulse');
     return item;

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -150,7 +150,7 @@ export function parseRoster(teamMdPath: string): AgentInfo[] {
     const content = fs.readFileSync(teamMdPath, 'utf-8');
     const agents: AgentInfo[] = [];
 
-    const membersMatch = content.match(/##\s+Members\s+\|[\s\S]*?(?=\n##|\n\n##|$)/i);
+    const membersMatch = content.match(/##\s+Members\s*\n+\|[\s\S]*?(?=\n##|\n\n##|$)/i);
     if (!membersMatch) return [];
 
     const tableContent = membersMatch[0];


### PR DESCRIPTION
Closes #176, closes #178, closes #179, closes #177

## Changes

### #176 — Fix Copilot CLI default provider settings
- `versionCommand`: `copilot --version` → `copilot version`
- `updateCommand`: empty → `copilot update`
- `upToDatePattern`: `up to date` → `latest version`

### #178 — Squad roster empty
- `parseRoster()` regex now allows blank lines between `## Members` heading and table
- Was: `/##\s+Members\s+\|/` (required table on same line)
- Now: `/##\s+Members\s*\n+\|/` (allows newlines between heading and table)

### #179 — Duplicate tree item IDs
- Agent items now get `\$\{squadId\}:agent:\$\{name\}` IDs
- Decision items: `\$\{squadId\}:decision:\$\{index\}`
- Activity items: `\$\{squadId\}:activity:\$\{index\}`
- No longer share the bare `squadId` which caused 'already registered' errors

### #177 — Terminal fullscreen on tab switch
- Added 150ms debounce to `onDidChangeVisibleTextEditors` handler
- Transient zero-editor states during tab switches are now ignored
- Added test case for rapid tab-switch scenario

## Tests
465 tests pass (all 24 suites)