### PR TITLE
feat: improve squad inbox UX with actionable notifications (#36)

### DIFF
--- a/src/__tests__/notifications.test.ts
+++ b/src/__tests__/notifications.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockGet, mockShowWarningMessage } = vi.hoisted(() => ({
+const { mockGet, mockShowWarningMessage, mockExecuteCommand } = vi.hoisted(() => ({
   mockGet: vi.fn(),
-  mockShowWarningMessage: vi.fn(),
+  mockShowWarningMessage: vi.fn().mockResolvedValue(undefined),
+  mockExecuteCommand: vi.fn(),
 }));
 
 vi.mock('vscode', () => ({
@@ -13,6 +14,9 @@ vi.mock('vscode', () => ({
   },
   window: {
     showWarningMessage: mockShowWarningMessage,
+  },
+  commands: {
+    executeCommand: mockExecuteCommand,
   },
 }));
 
@@ -125,7 +129,8 @@ describe('NotificationManager.checkAndNotify', () => {
     manager.checkAndNotify(config, makeState({ inboxCount: 3 }));
 
     expect(mockShowWarningMessage).toHaveBeenCalledWith(
-      '🧪 Test Squad: 3 decision(s) pending',
+      '🧪 Test Squad: 3 decision(s) pending review',
+      'Review',
     );
   });
 

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -241,7 +241,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         tooltipLines.push(`Last activity: ${cached.lastActivity}`);
       }
       if (cached.inboxCount > 0) {
-        tooltipLines.push(`Inbox: ${cached.inboxCount} item(s)`);
+        tooltipLines.push(`Inbox: ${cached.inboxCount} item(s) — agents have submitted decisions for your review`);
       }
     }
     item.tooltip = new vscode.MarkdownString(tooltipLines.join('\n\n'));
@@ -327,6 +327,9 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
       'decisions',
     );
     decisionItem.iconPath = new vscode.ThemeIcon('law');
+    if (state.inboxCount > 0) {
+      decisionItem.description = `📥 ${state.inboxCount} pending review`;
+    }
     children.push(decisionItem);
 
     // Activity

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -16,9 +16,12 @@ export class NotificationManager {
     const currentCount = state.inboxCount;
 
     if (previousCount === 0 && currentCount > 0 && isNotificationEnabled('inbox')) {
-      vscode.window.showWarningMessage(
-        `${config.icon} ${config.name}: ${currentCount} decision(s) pending`,
-      );
+      const msg = `${config.icon} ${config.name}: ${currentCount} decision(s) pending review`;
+      vscode.window.showWarningMessage(msg, 'Review').then(choice => {
+        if (choice === 'Review') {
+          vscode.commands.executeCommand('editlessTree.focus');
+        }
+      });
     }
 
     this._previousCounts.set(config.id, currentCount);


### PR DESCRIPTION
Closes #36

## Problem
First-time users don't understand what the squad inbox is or what action to take when decisions are pending.

## Changes
- **Actionable notification**: toast now says 'pending review' and includes a 'Review' button that focuses the Agents panel
- **Descriptive tooltip**: inbox tooltip explains 'agents have submitted decisions for your review'
- **Inline pending count**: Decisions category shows '📥 N pending review' description when inbox has items

## Tests
465 tests pass. Updated notification mock to return a Promise and assert the new message format + action button.