### PR TITLE
chore: flush decisions inbox — remove go: label namespace

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -486,3 +486,33 @@ Final pre-release triage of all 25 open issues. Deadline: Monday evening (~16 ho
 
 **Why:** All P0 items assigned and labeled. Squad can execute immediately. P1 items are important but not blocking. Docs/marketplace work can follow in patch/v0.2. #38 honors the issue author's explicit "future work" intent.
 
+
+
+# Decision: Remove go: label namespace
+
+**By:** Birdperson (DevOps)
+**Date:** 2026-02-16
+**Requested by:** Casey Irvine
+
+## What changed
+
+The `go:` label namespace (`go:yes`, `go:no`, `go:needs-research`) has been removed from all workflows and the repo.
+
+Triage no longer applies `go:needs-research` unconditionally. Instead, it applies `status:needs-plan` only when the issue has no existing `status:` label — preserving any status already set.
+
+Release labels trimmed to `release:v0.1` and `release:backlog`.
+
+## Why
+
+The go/no-go gate added friction without value at current project scale. The `status:` labels already capture workflow state (`needs-plan` → `planned` → `in-progress`). Fewer labels, cleaner triage.
+
+## What agents should know
+
+- Do not reference `go:` labels in code, workflows, or documentation.
+- Triage default is now `status:needs-plan` (not `go:needs-research`).
+- Available release targets are `release:v0.1` and `release:backlog` only.
+
+### 2026-02-16: Remove go:* labels, fix triage to use status: labels
+**By:** Casey Irvine (via Copilot)
+**What:** Remove the entire go:* label namespace (go:yes, go:no, go:needs-research). Release labels are only release:v0.1 and release:backlog. Triage should apply status:needs-plan or status:planned instead of go:needs-research, and must NOT overwrite existing status: labels.
+**Why:** User request — simplifying the label scheme and fixing triage overwrite behavior.

--- a/.ai-team/decisions/inbox/copilot-directive-remove-go-labels.md
+++ b/.ai-team/decisions/inbox/copilot-directive-remove-go-labels.md
@@ -1,4 +1,0 @@
-### 2026-02-16: Remove go:* labels, fix triage to use status: labels
-**By:** Casey Irvine (via Copilot)
-**What:** Remove the entire go:* label namespace (go:yes, go:no, go:needs-research). Release labels are only release:v0.1 and release:backlog. Triage should apply status:needs-plan or status:planned instead of go:needs-research, and must NOT overwrite existing status: labels.
-**Why:** User request — simplifying the label scheme and fixing triage overwrite behavior.


### PR DESCRIPTION
Flushes two pending inbox decisions into decisions.md and removes the inbox files:

- **Birdperson**: Remove go:* label namespace, simplify to status: labels
- **Copilot directive**: Remove go:* labels, fix triage to use status: labels

These were sitting as unstaged changes on master from a previous inbox flush.