### PR TITLE
fix: workspace auto-detect squads, filter cache invalidation (#194, #201)

### DIFF
--- a/src/__tests__/agency-surface-audit.test.ts
+++ b/src/__tests__/agency-surface-audit.test.ts
@@ -20,7 +20,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 const SKIP_DIRS = new Set([
   '.ai-team', '.ai-team-templates', 'node_modules', 'dist', 'out',
-  '__tests__', '__integration__', '.git', 'icons',
+  '__tests__', '__integration__', '.git', 'icons', '.vscode-test',
 ]);
 
 const TEXT_EXTENSIONS = new Set([

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -287,6 +287,7 @@ vi.mock('../cli-provider', () => ({
 vi.mock('../discovery', () => ({
   registerDiscoveryCommand: vi.fn(() => ({ dispose: vi.fn() })),
   checkDiscoveryOnStartup: vi.fn(),
+  autoRegisterWorkspaceSquads: vi.fn(),
 }));
 
 vi.mock('../agent-discovery', () => ({

--- a/src/__tests__/work-items-tree.test.ts
+++ b/src/__tests__/work-items-tree.test.ts
@@ -402,6 +402,21 @@ describe('WorkItemsTreeProvider — runtime filter', () => {
     expect(provider.isFiltered).toBe(false);
   });
 
+  it('should exclude items with non-matching release label (#194)', async () => {
+    const items = await getFilteredItems(
+      [
+        makeIssue({ number: 1, labels: ['release:v0.1', 'type:bug'] }),
+        makeIssue({ number: 2, labels: ['release:backlog', 'type:bug'] }),
+        makeIssue({ number: 3, labels: ['release:v0.1', 'priority:p1'] }),
+      ],
+      { labels: ['release:v0.1'] },
+    );
+    expect(items).toHaveLength(2);
+    expect(items.map(i => i.label)).toEqual(
+      expect.arrayContaining([expect.stringContaining('#1'), expect.stringContaining('#3')]),
+    );
+  });
+
   it('should collect all unique labels from issues', async () => {
     mockIsGhAvailable.mockResolvedValue(true);
     mockFetchAssignedIssues.mockResolvedValue([

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { TerminalManager } from './terminal-manager';
 import { SessionLabelManager, promptClearLabel } from './session-labels';
 import { registerSquadUpgradeCommand, registerSquadUpgradeAllCommand, checkSquadUpgradesOnStartup, clearLatestVersionCache } from './squad-upgrader';
 import { registerCliUpdateCommand, checkProviderUpdatesOnStartup, probeAllProviders, resolveActiveProvider, getActiveCliProvider } from './cli-provider';
-import { registerDiscoveryCommand, checkDiscoveryOnStartup } from './discovery';
+import { registerDiscoveryCommand, checkDiscoveryOnStartup, autoRegisterWorkspaceSquads } from './discovery';
 import { discoverAllAgents } from './agent-discovery';
 import { AgentVisibilityManager } from './visibility';
 import { SquadWatcher } from './watcher';
@@ -44,6 +44,9 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   // --- Registry ----------------------------------------------------------
   const registry = createRegistry(context);
   registry.loadSquads();
+
+  // --- Auto-register workspace squads (#201) --------------------------------
+  autoRegisterWorkspaceSquads(registry);
 
   // --- Auto-flush decisions inbox (#66) ------------------------------------
   for (const squad of registry.loadSquads()) {


### PR DESCRIPTION
## Changes

### #201 — Squad roster not populating
The extension wasn't auto-detecting squads at workspace roots. If a workspace folder has \.ai-team/\ or \.squad/\ with a \	eam.md\, it's now silently registered on activation — no manual discovery or registry entry needed.

### #194 — Filter still showing backlog items
The runtime filter logic (AND/every) is correct — tests confirm it. However, VS Code's TreeView may cache child items by stable \id\ across \ire()\ calls. Group item IDs (\wi:repo\, \ms:milestone\) were static, so VS Code could reuse stale children after filter changes.

Fix: Added a \_filterSeq\ counter that increments on every \setFilter()\ call. Group IDs now include the filter sequence (\wi:repo:f3\), forcing VS Code to treat them as new items and re-request children.

### Agency audit fix
Added \.vscode-test/\ to skip list — downloaded VS Code binaries contain license files with the word 'agency'.

## Tests
- 470 tests pass (4 new)
- Exact repro test for #194: release:v0.1 filter with backlog items
- 4 tests for \utoRegisterWorkspaceSquads\

Closes #201