### PR TITLE
docs: README polish — worktree tips and agent setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ No experience with agentic development required. No complex setup. Just install,
 
 - **Use [SquadUI](https://marketplace.visualstudio.com/items?itemName=csharpfritz.squadui) for a richer dashboard.** It adds team visualization, skill management, and a squad dashboard right in VS Code. EditLess integrates with it — you'll see "Open in Squad UI" in your context menus.
 
-- **Use [git worktrees](https://git-scm.com/docs/git-worktree) for parallel agent work.** Worktrees let multiple agents work on the same repo simultaneously — each in its own branch, each in its own directory. No checkout conflicts, no stepping on each other's work. If you're running multiple sessions across the same project, worktrees are a game changer.
+- **Use [git worktrees](https://git-scm.com/docs/git-worktree) for parallel agent work.** Worktrees let multiple agents work on the same repo simultaneously — each in its own branch, each in its own directory. No checkout conflicts, no stepping on each other's work. You don't even need to set them up yourself — just ask your agent to create a worktree and get to work.
 
 ## Documentation
 


### PR DESCRIPTION
Adds git worktrees quick tip with guidance to let agents set them up for you.

Follow-up to PR #203 which merged the bulk of README docs work.

Continuation of the docs-vibing session.