### PR TITLE
fix: add -y flag to all npx calls to prevent hidden terminal hang

### DIFF
--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -1760,7 +1760,7 @@ describe('extension command handlers', () => {
         cwd: '/path/to/squad',
         hideFromUser: true,
       });
-      expect(mockTerminal.sendText).toHaveBeenCalledWith('git init && npx github:bradygaster/squad init; exit');
+      expect(mockTerminal.sendText).toHaveBeenCalledWith('git init && npx -y github:bradygaster/squad init; exit');
     });
 
     it('should run squad upgrade command for existing squad directory', async () => {
@@ -1776,7 +1776,7 @@ describe('extension command handlers', () => {
         cwd: '/path/to/squad',
         hideFromUser: true,
       });
-      expect(mockTerminal.sendText).toHaveBeenCalledWith('npx github:bradygaster/squad upgrade; exit');
+      expect(mockTerminal.sendText).toHaveBeenCalledWith('npx -y github:bradygaster/squad upgrade; exit');
     });
 
     it('should show success notification for new squad', async () => {
@@ -1828,7 +1828,7 @@ describe('extension command handlers', () => {
       expect(mockShowOpenDialog).toHaveBeenCalled();
       expect(mockIsSquadInitialized).toHaveBeenCalledWith('/squad-dir');
       expect(mockCreateTerminal).toHaveBeenCalled();
-      expect(mockTerminal.sendText).toHaveBeenCalledWith('git init && npx github:bradygaster/squad init; exit');
+      expect(mockTerminal.sendText).toHaveBeenCalledWith('git init && npx -y github:bradygaster/squad init; exit');
       expect(mockShowInformationMessage).toHaveBeenCalled();
     });
 
@@ -1845,7 +1845,7 @@ describe('extension command handlers', () => {
       expect(mockShowOpenDialog).toHaveBeenCalled();
       expect(mockIsSquadInitialized).toHaveBeenCalledWith('/existing-squad');
       expect(mockCreateTerminal).toHaveBeenCalled();
-      expect(mockTerminal.sendText).toHaveBeenCalledWith('npx github:bradygaster/squad upgrade; exit');
+      expect(mockTerminal.sendText).toHaveBeenCalledWith('npx -y github:bradygaster/squad upgrade; exit');
       expect(mockShowInformationMessage).toHaveBeenCalledWith(
         'Squad upgrade started in existing-squad.',
       );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1098,8 +1098,8 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
       const dirPath = uris[0].fsPath;
       const squadExists = isSquadInitialized(dirPath);
       const command = squadExists 
-        ? 'npx github:bradygaster/squad upgrade'
-        : 'git init && npx github:bradygaster/squad init';
+        ? 'npx -y github:bradygaster/squad upgrade'
+        : 'git init && npx -y github:bradygaster/squad init';
       const action = squadExists ? 'Upgrade' : 'Init';
 
       const terminal = vscode.window.createTerminal({

--- a/src/squad-upgrader.ts
+++ b/src/squad-upgrader.ts
@@ -149,7 +149,7 @@ export async function runSquadUpgrade(config: AgentTeamConfig): Promise<void> {
     },
     () =>
       new Promise<void>((resolve) => {
-        exec('npx github:bradygaster/squad upgrade', { cwd: config.path }, (err, stdout, stderr) => {
+        exec('npx -y github:bradygaster/squad upgrade', { cwd: config.path }, (err, stdout, stderr) => {
           if (err) {
             const msg = stderr?.trim() || err.message;
             vscode.window.showErrorMessage(`${config.icon} Squad upgrade failed for ${config.name}: ${msg}`);


### PR DESCRIPTION
## Problem

\
px github:bradygaster/squad init\ and \
px github:bradygaster/squad upgrade\ prompt for install confirmation when the package isn't cached. Since \ddSquad\ runs in a hidden terminal (\hideFromUser: true\), nobody can answer the prompt, causing the init/upgrade to hang silently forever.

The npx debug log confirmed this — it stops at \packumentCache\ entries with no resolution or execution.

## Fix

Added \-y\ flag to all three \
px\ call sites:

- **\xtension.ts\** — init and upgrade commands via hidden terminal
- **\squad-upgrader.ts\** — background upgrade via \xec()\

## Testing

All 680 tests pass. Updated 4 test assertions to match the new command strings.

Closes #232 regression area — squad add was silently failing.