### PR TITLE
Remove custom agent creation command remnants

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -172,24 +172,6 @@ Settings for controlling desktop toasts and notifications.
 
 ---
 
-## Agent Creation
-
-Settings for customizing the agent creation workflow.
-
-| Setting | Type | Default | Scope | Description |
-|---------|------|---------|-------|-------------|
-| `editless.agentCreationCommand` | `string` | `""` | resource | Custom command to run when adding an agent. Overrides the built-in agent creation flow. Supports variable substitution: `${workspaceFolder}` (workspace root path) and `${agentName}` (user-entered agent name). |
-
-**Example — use a custom initialization script:**
-
-```jsonc
-{
-  "editless.agentCreationCommand": "my-tool init --name ${agentName} --dir ${workspaceFolder}/squads"
-}
-```
-
----
-
 ## Complete Example `settings.json`
 
 ```jsonc
@@ -220,10 +202,7 @@ Settings for customizing the agent creation workflow.
   // Notifications
   "editless.notifications.enabled": true,
   "editless.notifications.inbox": true,
-  "editless.notifications.updates": true,
-
-  // Agent Creation
-  "editless.agentCreationCommand": ""
+  "editless.notifications.updates": true
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,6 @@ All settings are prefixed `editless.*` and defined in `package.json` contributes
 | **Azure DevOps** | `ado.organization`, `ado.project` |
 | **Notifications** | `notifications.enabled`, `notifications.inbox`, `notifications.updates` |
 | **Auto-refresh** | `refreshInterval`, `scanDebounceMs` |
-| **Display** | `agentCreationCommand` |
 
 ### Views & Tree Items
 

--- a/package.json
+++ b/package.json
@@ -485,14 +485,6 @@
           "markdownDescription": "Auto-refresh interval in minutes for the **Work Items** and **Pull Requests** panels.\n\nEditLess also refreshes when the VS Code window regains focus.\n\nSet to `0` to disable auto-refresh entirely (manual refresh only).\n\nDefault: `5` minutes.",
           "scope": "window",
           "order": 34
-        },
-        "editless.agentCreationCommand": {
-          "type": "string",
-          "default": "",
-          "description": "Custom command to run when adding an agent. Overrides built-in flow. Supports ${workspaceFolder} and ${agentName}.",
-          "markdownDescription": "Custom command to run when adding an agent. Overrides the built-in agent creation flow.\n\nSupports variable substitution:\n- `${workspaceFolder}` — path to the current workspace\n- `${agentName}` — name entered by the user\n\nExample: `\"my-tool init --name ${agentName} --dir ${workspaceFolder}\"`",
-          "scope": "resource",
-          "order": 21
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -924,20 +924,6 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
       });
       if (!name) return;
 
-      const customCommand = vscode.workspace.getConfiguration('editless').get<string>('agentCreationCommand');
-      if (typeof customCommand === 'string' && customCommand.trim()) {
-        const command = customCommand
-          .replace(/\$\{workspaceFolder\}/g, workspaceFolder.uri.fsPath)
-          .replace(/\$\{agentName\}/g, name.trim());
-        const terminal = vscode.window.createTerminal({
-          name: `Add Agent: ${name.trim()}`,
-          cwd: workspaceFolder.uri.fsPath,
-        });
-        terminal.show();
-        terminal.sendText(command);
-        return;
-      }
-
       type SourceValue = 'create' | 'import';
       const sourceItems: { label: string; description: string; value: SourceValue }[] = [
         { label: '$(add) Create new', description: 'Create from template or CLI provider', value: 'create' },


### PR DESCRIPTION
Closes #311

Removes the last traces of the custom commands feature — the agentCreationCommand setting and its handler in the addAgent flow. This feature went through a full build-ship-break-remove cycle and shouldn't be reimplemented without a proper design.

## Changes
- Removed editless.agentCreationCommand setting from package.json
- Removed custom command handler block from addAgent in extension.ts
- Built-in agent creation flow now always runs
- Removed all references from docs (SETTINGS.md, architecture.md)