### PR TITLE
fix: remove misleading SquadStatus from tree view

### DIFF
--- a/src/__tests__/scanner.test.ts
+++ b/src/__tests__/scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { parseRoster, extractReferences, determineStatus, scanSquad } from '../scanner';
+import { parseRoster, extractReferences, scanSquad } from '../scanner';
 import type { AgentTeamConfig } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -127,31 +127,6 @@ describe('extractReferences', () => {
 });
 
 // ---------------------------------------------------------------------------
-// determineStatus
-// ---------------------------------------------------------------------------
-
-describe('determineStatus', () => {
-  it('returns active for recent activity (< 1 hour)', () => {
-    const recent = new Date(Date.now() - 10 * 60 * 1000); // 10 min ago
-    expect(determineStatus(recent)).toBe('active');
-  });
-
-  it('returns needs-attention for old activity (> 1 day)', () => {
-    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
-    expect(determineStatus(old)).toBe('needs-attention');
-  });
-
-  it('returns idle for activity between 1 hour and 1 day', () => {
-    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000);
-    expect(determineStatus(fiveHoursAgo)).toBe('idle');
-  });
-
-  it('returns needs-attention when lastActivity is null', () => {
-    expect(determineStatus(null)).toBe('needs-attention');
-  });
-});
-
-// ---------------------------------------------------------------------------
 // scanSquad (integration)
 // ---------------------------------------------------------------------------
 
@@ -169,7 +144,6 @@ describe('scanSquad', () => {
 
   it('returns error state when neither .squad/ nor .ai-team/ exists', () => {
     const state = scanSquad(makeConfig());
-    expect(state.status).toBe('idle');
     expect(state.error).toContain('.squad/ (or .ai-team/) directory not found');
     expect(state.roster).toEqual([]);
   });

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -199,9 +199,6 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     const descParts: string[] = [cfg.universe];
 
     const cached = this._cache.get(cfg.id);
-    if (cached) {
-      descParts.push(cached.status);
-    }
     if (this.terminalManager) {
       const count = this.terminalManager.getTerminalsForSquad(cfg.id).length;
       if (count > 0) {
@@ -222,11 +219,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
       tooltipLines.push(`Squad Version: ${localVersion}`);
     }
 
-    if (cached) {
-      tooltipLines.push(`Status: ${cached.status}`);
-      if (cached.lastActivity) {
-        tooltipLines.push(`Last activity: ${cached.lastActivity}`);
-      }
+    if (cached?.lastActivity) {
+      tooltipLines.push(`Last activity: ${cached.lastActivity}`);
     }
     item.tooltip = new vscode.MarkdownString(tooltipLines.join('\n\n'));
     item.iconPath = new vscode.ThemeIcon('organization');

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,16 +25,6 @@ export interface AgentTeamConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Squad Status
-// ---------------------------------------------------------------------------
-
-/** Runtime status of a squad. */
-export type SquadStatus =
-  | 'active'          // recent activity (file changes within last hour)
-  | 'idle'            // no recent activity
-  | 'needs-attention'; // no activity for >1 day
-
-// ---------------------------------------------------------------------------
 // Parsed Content Entries
 // ---------------------------------------------------------------------------
 
@@ -85,7 +75,6 @@ export interface SessionContext {
 /** Full runtime state of a squad — what the dashboard shows per squad. */
 export interface SquadState {
   config: AgentTeamConfig;
-  status: SquadStatus;
   /** ISO timestamp of most recent file change, or null if unknown */
   lastActivity: string | null;
   /** Set if squad path is inaccessible or scanning failed */


### PR DESCRIPTION
The squad status (active/idle/needs-attention) shown in the tree view is based on file modification times, which is a fragile heuristic that can mislead users about actual squad health. Removing the status from the UI and cleaning up the now-unused infrastructure.

- Remove status from tree view description and tooltip
- Remove \SquadStatus\ type, \determineStatus()\, and time constants from scanner
- Remove \status\ field from \SquadState\ interface
- Remove \determineStatus\ tests; update \scanSquad\ test assertions

Requested by Casey.