### PR TITLE
fix: remove duplicate time and summary from session tree item

### DIFF
--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -259,12 +259,10 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         const relative = mins < 1 ? 'just now' : mins < 60 ? `${mins}m ago` : `${Math.floor(mins / 60)}h ago`;
 
         const customLabel = this.labelManager?.getLabel(info.labelKey);
-        const renamedTitle = sessionCtx?.summary?.trim();
-        const fallbackTitle = renamedTitle && renamedTitle.length > 0 ? renamedTitle : info.displayName;
-        const title = customLabel ? `🏷️ ${customLabel}` : fallbackTitle;
+        const title = customLabel ? `🏷️ ${customLabel}` : info.displayName;
         const item = new EditlessTreeItem(title, 'terminal');
         item.terminal = terminal;
-        item.description = this._buildTerminalDescription(null, relative, sessionCtx, sessionState, lastActivityAt);
+        item.description = relative;
         item.iconPath = getStateIcon(sessionState);
         item.contextValue = 'terminal';
         item.tooltip = this._buildTerminalTooltip(info.displayName, relative, sessionCtx, sessionState, lastActivityAt);
@@ -383,34 +381,6 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   }
 
   // -- Session context helpers ----------------------------------------------
-
-  private _buildTerminalDescription(
-    terminalName: string | null,
-    relative: string,
-    ctx: SessionContext | null,
-    sessionState: SessionState,
-    lastActivityAt?: number,
-  ): string {
-    const parts: string[] = [];
-    if (terminalName) parts.push(terminalName);
-    
-    const stateDesc = getStateDescription(sessionState, lastActivityAt);
-    if (stateDesc) parts.push(stateDesc);
-
-    if (ctx) {
-      if (ctx.summary) {
-        parts.push(ctx.summary);
-      } else if (ctx.branch) {
-        parts.push(`⎇ ${ctx.branch}`);
-      }
-      if (ctx.references.length > 0) {
-        parts.push(ctx.references.map(r => r.label).join(' · '));
-      }
-    }
-
-    parts.push(relative);
-    return parts.join(' · ');
-  }
 
   private _buildTerminalTooltip(
     terminalName: string,


### PR DESCRIPTION
Closes #358

Three fixes to the session tree item:
1. **Stabilize the title** - Use info.displayName as the stable default label, not the auto-updating sessionCtx.summary
2. **Single time only** - Description shows only creation-relative time (10m ago), not both activity time and creation time
3. **Remove duplicate summary** - Session summary no longer repeated in description (was showing as both label and description)

Deleted _buildTerminalDescription (30 lines) - dead code after simplifying description to just relative. Tooltip still has full context (summary, branch, refs, timestamps).

Per UX convention: Icon=state, Label=what, Description=time only, Tooltip=full context.