### PR TITLE
fix: trigger squad discovery on refresh button (#317)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,8 +279,12 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
     vscode.commands.registerCommand('editless.refresh', () => {
       discoveredAgents = discoverAllAgents(vscode.workspace.workspaceFolders ?? []);
       treeProvider.setDiscoveredAgents(discoveredAgents);
+      autoRegisterWorkspaceSquads(registry);
+      checkDiscoveryOnStartup(context, registry);
       treeProvider.refresh();
-      output.appendLine('[refresh] Tree refreshed');
+      squadWatcher.updateSquads(registry.loadSquads());
+      statusBar.update();
+      output.appendLine('[refresh] Tree refreshed (agents + squads)');
     }),
   );
 


### PR DESCRIPTION
## Summary

The \ditless.refresh\ command handler only re-discovered standalone \.agent.md\ files. Squads added to workspace directories after activation were invisible until VS Code restarted.

## Changes

Added \utoRegisterWorkspaceSquads(registry)\ and \checkDiscoveryOnStartup(context, registry)\ to the refresh handler in \src/extension.ts\, matching the pattern used by the workspace file watcher (lines 148-152). Also updates \squadWatcher\ and \statusBar\ to reflect the new state.

## Testing

All 569 existing tests pass. No new test needed — this wires existing, tested functions into an additional call site.

Closes #317