### PR TITLE
fix: agent picker includes Copilot CLI + roster hides launch button (#420, #419)

### DIFF
--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -517,10 +517,14 @@ describe('extension command handlers', () => {
   // --- editless.launchSession -----------------------------------------------
 
   describe('editless.launchSession', () => {
-    it('should show warning when no agents discovered', async () => {
+    it('should always include built-in Copilot CLI in picker', async () => {
       mockTreeGetDiscoveredItems.mockReturnValue([]);
+      mockShowQuickPick.mockResolvedValue(undefined);
       await getHandler('editless.launchSession')();
-      expect(mockShowWarningMessage).toHaveBeenCalledWith('No agents discovered yet.');
+      expect(mockShowQuickPick).toHaveBeenCalledWith(
+        [expect.objectContaining({ label: '$(terminal) Copilot CLI', id: 'builtin:copilot-cli' })],
+        expect.anything(),
+      );
       expect(mockLaunchTerminal).not.toHaveBeenCalled();
     });
 
@@ -1515,10 +1519,15 @@ describe('extension command handlers', () => {
   // --- editless.launchFromWorkItem -------------------------------------------
 
   describe('editless.launchFromWorkItem', () => {
-    it('should show warning when no agents discovered', async () => {
+    it('should always include built-in Copilot CLI in work item picker', async () => {
       const item = { issue: { number: 42, title: 'Fix bug', url: 'https://example.com/42' } };
+      mockShowQuickPick.mockResolvedValue(undefined);
       await getHandler('editless.launchFromWorkItem')(item);
-      expect(mockShowWarningMessage).toHaveBeenCalledWith('No agents discovered.');
+      expect(mockShowQuickPick).toHaveBeenCalledWith(
+        [expect.objectContaining({ label: '$(terminal) Copilot CLI' })],
+        expect.anything(),
+      );
+      expect(mockLaunchAndLabel).not.toHaveBeenCalled();
     });
 
     it('should show QuickPick and launch terminal for selected agent', async () => {
@@ -1950,10 +1959,15 @@ describe('additional extension command handlers', () => {
   // --- editless.launchFromPR -------------------------------------------------
 
   describe('editless.launchFromPR', () => {
-    it('should show warning when no agents discovered', async () => {
+    it('should always include built-in Copilot CLI in PR picker', async () => {
       const item = { pr: { number: 100, title: 'Add feature', url: 'https://github.com/owner/repo/pull/100' } };
+      mockShowQuickPick.mockResolvedValue(undefined);
       await getHandler('editless.launchFromPR')(item);
-      expect(mockShowWarningMessage).toHaveBeenCalledWith('No agents discovered.');
+      expect(mockShowQuickPick).toHaveBeenCalledWith(
+        [expect.objectContaining({ label: '$(terminal) Copilot CLI' })],
+        expect.anything(),
+      );
+      expect(mockLaunchAndLabel).not.toHaveBeenCalled();
     });
 
     it('should show QuickPick and launch terminal for GitHub PR', async () => {

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -19,6 +19,17 @@ export type TreeItemType = 'squad' | 'squad-hidden' | 'category' | 'agent' | 'te
 
 /** Sentinel ID for the built-in Copilot CLI entry. */
 export const DEFAULT_COPILOT_CLI_ID = 'builtin:copilot-cli';
+
+/** Build the AgentTeamConfig for the built-in Copilot CLI agent. */
+export function buildCopilotCLIConfig(cwd?: string): AgentTeamConfig {
+  return {
+    id: DEFAULT_COPILOT_CLI_ID,
+    name: 'Copilot CLI',
+    path: cwd ?? '',
+    icon: '🤖',
+    universe: 'standalone',
+  };
+}
 type CategoryKind = 'roster' | 'hidden';
 
 function stableHash(input: string): string {
@@ -496,6 +507,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
 
   private buildAgentItem(agent: AgentInfo, squadId?: string): EditlessTreeItem {
     const item = new EditlessTreeItem(agent.name, 'agent', vscode.TreeItemCollapsibleState.None);
+    item.contextValue = 'roster-agent';
     if (squadId) {
       const state = this.getState(squadId);
       const squadPath = state?.config.path ?? squadId;


### PR DESCRIPTION
Closes #420
Closes #419

Two related tree view fixes from Russ's dogfooding feedback.

**Agent picker (#420):** Created getAllAgentsForPicker() helper that always includes the built-in Copilot CLI agent.
**Roster button (#419):** Changed roster contextValue to 'roster-agent' to exclude from launch button.

All 826+ tests pass.