### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editless",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditLess",
   "description": "Plan, delegate, and review your AI team's work — the editorless development panel",
   "publisher": "cirvine-MSFT",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump for v0.1.3 release. After merge, push the \0.1.3\ tag to trigger the release pipeline.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>