### PR TITLE
refactor: extract AgentStateManager from editless-tree.ts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,7 +198,8 @@ export function activate(context: vscode.ExtensionContext) {
   const terminalManager = new TerminalManager(context);
 
   // 6. Tree providers
-  const editlessTree = new EditlessTreeProvider(registry, terminalManager, ...);
+  const agentStateManager = new AgentStateManager(agentSettings);
+  const editlessTree = new EditlessTreeProvider(agentStateManager, agentSettings, terminalManager, ...);
   vscode.window.registerTreeDataProvider('editlessTree', editlessTree);
 
   const workItems = new WorkItemsTreeProvider(...);

--- a/src/__tests__/agent-state-manager.test.ts
+++ b/src/__tests__/agent-state-manager.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => ({
+  EventEmitter: class {
+    private listeners: Array<() => void> = [];
+    event = (listener: () => void) => {
+      this.listeners.push(listener);
+      return { dispose: () => { this.listeners = this.listeners.filter(l => l !== listener); } };
+    };
+    fire = () => { for (const l of this.listeners) l(); };
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock('../scanner', () => ({
+  scanSquad: vi.fn((cfg: unknown) => ({
+    config: cfg,
+    lastActivity: null,
+    roster: [{ name: 'Alice', role: 'Dev' }],
+    charter: '',
+  })),
+}));
+
+import { AgentStateManager } from '../agent-state-manager';
+import { scanSquad } from '../scanner';
+import type { DiscoveredItem } from '../unified-discovery';
+
+function makeItem(id: string, overrides?: Partial<DiscoveredItem>): DiscoveredItem {
+  return {
+    id,
+    name: id,
+    type: 'squad',
+    source: 'workspace',
+    path: `/path/${id}`,
+    universe: 'test',
+    ...overrides,
+  };
+}
+
+function makeMockSettings(items: DiscoveredItem[] = []) {
+  return {
+    get: vi.fn((id: string) => {
+      const item = items.find(i => i.id === id);
+      return item ? { name: item.name, icon: '🔷' } : undefined;
+    }),
+  };
+}
+
+describe('AgentStateManager', () => {
+  let mgr: AgentStateManager;
+  let mockSettings: ReturnType<typeof makeMockSettings>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettings = makeMockSettings();
+    mgr = new AgentStateManager(mockSettings as never);
+  });
+
+  // -- setDiscoveredItems / getDiscoveredItems --------------------------------
+
+  it('starts with empty discovered items', () => {
+    expect(mgr.getDiscoveredItems()).toEqual([]);
+  });
+
+  it('setDiscoveredItems stores and returns items', () => {
+    const items = [makeItem('a'), makeItem('b')];
+    mgr.setDiscoveredItems(items);
+    expect(mgr.getDiscoveredItems()).toEqual(items);
+  });
+
+  it('setDiscoveredItems replaces previous items', () => {
+    mgr.setDiscoveredItems([makeItem('a')]);
+    mgr.setDiscoveredItems([makeItem('b')]);
+    expect(mgr.getDiscoveredItems()).toHaveLength(1);
+    expect(mgr.getDiscoveredItems()[0].id).toBe('b');
+  });
+
+  // -- getState ---------------------------------------------------------------
+
+  it('returns undefined for unknown squad', () => {
+    expect(mgr.getState('nonexistent')).toBeUndefined();
+  });
+
+  it('resolves state from discovered items + settings', () => {
+    const items = [makeItem('squad-a')];
+    mockSettings = makeMockSettings(items);
+    mgr = new AgentStateManager(mockSettings as never);
+    mgr.setDiscoveredItems(items);
+
+    const state = mgr.getState('squad-a');
+    expect(state).toBeDefined();
+    expect(state!.config.id).toBe('squad-a');
+    expect(state!.roster).toEqual([{ name: 'Alice', role: 'Dev' }]);
+    expect(scanSquad).toHaveBeenCalledOnce();
+  });
+
+  it('caches state on second call', () => {
+    mgr.setDiscoveredItems([makeItem('squad-a')]);
+    mgr.getState('squad-a');
+    mgr.getState('squad-a');
+    expect(scanSquad).toHaveBeenCalledOnce();
+  });
+
+  // -- invalidate -------------------------------------------------------------
+
+  it('invalidate clears specific cache entry', () => {
+    mgr.setDiscoveredItems([makeItem('a'), makeItem('b')]);
+    mgr.getState('a');
+    mgr.getState('b');
+    expect(scanSquad).toHaveBeenCalledTimes(2);
+
+    mgr.invalidate('a');
+    mgr.getState('a');
+    expect(scanSquad).toHaveBeenCalledTimes(3);
+    // 'b' still cached
+    mgr.getState('b');
+    expect(scanSquad).toHaveBeenCalledTimes(3);
+  });
+
+  // -- invalidateAll ----------------------------------------------------------
+
+  it('invalidateAll clears all cache entries', () => {
+    mgr.setDiscoveredItems([makeItem('a'), makeItem('b')]);
+    mgr.getState('a');
+    mgr.getState('b');
+    expect(scanSquad).toHaveBeenCalledTimes(2);
+
+    mgr.invalidateAll();
+    mgr.getState('a');
+    mgr.getState('b');
+    expect(scanSquad).toHaveBeenCalledTimes(4);
+  });
+
+  // -- onDidChange event ------------------------------------------------------
+
+  it('fires onDidChange when discovered items are set', () => {
+    const listener = vi.fn();
+    mgr.onDidChange(listener);
+    mgr.setDiscoveredItems([makeItem('a')]);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('fires onDidChange on invalidate', () => {
+    const listener = vi.fn();
+    mgr.onDidChange(listener);
+    mgr.invalidate('x');
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('fires onDidChange on invalidateAll', () => {
+    const listener = vi.fn();
+    mgr.onDidChange(listener);
+    mgr.invalidateAll();
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/auto-refresh.test.ts
+++ b/src/__tests__/auto-refresh.test.ts
@@ -31,6 +31,11 @@ vi.mock('../editless-tree', () => ({
   }),
   EditlessTreeItem: class {},
 }));
+vi.mock('../agent-state-manager', () => ({
+  AgentStateManager: vi.fn(function () {
+    return { getState: vi.fn(), invalidate: vi.fn(), invalidateAll: vi.fn(), setDiscoveredItems: vi.fn(), getDiscoveredItems: vi.fn().mockReturnValue([]), onDidChange: vi.fn(() => ({ dispose: vi.fn() })), dispose: vi.fn() };
+  }),
+}));
 vi.mock('../terminal-manager', () => ({ TerminalManager: vi.fn(function () { return { persist: vi.fn(), reconcile: vi.fn(), waitForReconciliation: vi.fn().mockResolvedValue(undefined), setSessionResolver: vi.fn(), setAgentSessionId: vi.fn(), getOrphanedSessions: vi.fn().mockReturnValue([]), onDidChange: vi.fn(() => ({ dispose: vi.fn() })), dispose: vi.fn(), getAllTerminals: vi.fn().mockReturnValue([]) }; }), EDITLESS_INSTRUCTIONS_DIR: '/mock/editless', getStateIcon: vi.fn(), getStateDescription: vi.fn() }));
 vi.mock('../session-labels', () => ({ SessionLabelManager: vi.fn(function () { return { getLabel: vi.fn(), setLabel: vi.fn(), clearLabel: vi.fn() }; }), promptClearLabel: vi.fn(), promptRenameSession: vi.fn() }));
 vi.mock('../squad-utils', () => ({ checkNpxAvailable: vi.fn().mockResolvedValue(true), promptInstallNode: vi.fn(), isSquadInitialized: vi.fn() }));

--- a/src/__tests__/config-refresh.test.ts
+++ b/src/__tests__/config-refresh.test.ts
@@ -110,6 +110,11 @@ vi.mock('../editless-tree', () => ({
   EditlessTreeItem: class {},
   DEFAULT_COPILOT_CLI_ID: 'builtin:copilot-cli',
 }));
+vi.mock('../agent-state-manager', () => ({
+  AgentStateManager: vi.fn(function () {
+    return { getState: vi.fn(), invalidate: vi.fn(), invalidateAll: vi.fn(), setDiscoveredItems: vi.fn(), getDiscoveredItems: vi.fn().mockReturnValue([]), onDidChange: vi.fn(() => ({ dispose: vi.fn() })), dispose: vi.fn() };
+  }),
+}));
 vi.mock('../agent-settings', () => ({
   createAgentSettings: vi.fn(() => ({
     get: vi.fn(),

--- a/src/__tests__/extension-commands-extra.test.ts
+++ b/src/__tests__/extension-commands-extra.test.ts
@@ -95,6 +95,11 @@ vi.mock('../editless-tree', () => ({
   },
   DEFAULT_COPILOT_CLI_ID: 'builtin:copilot-cli'
 }));
+vi.mock('../agent-state-manager', () => ({
+  AgentStateManager: class {
+    getState = vi.fn(); invalidate = vi.fn(); invalidateAll = vi.fn(); setDiscoveredItems = vi.fn(); getDiscoveredItems = vi.fn().mockReturnValue([]); onDidChange = vi.fn(() => ({ dispose: vi.fn() })); dispose = vi.fn();
+  },
+}));
 vi.mock('../unified-discovery', () => ({ discoverAll: vi.fn(() => []) }));
 vi.mock('../watcher', () => ({ SquadWatcher: class {} }));
 vi.mock('../status-bar', () => ({ EditlessStatusBar: class { 

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -242,6 +242,12 @@ vi.mock('../editless-tree', () => ({
   DEFAULT_COPILOT_CLI_ID: 'builtin:copilot-cli',
 }));
 
+vi.mock('../agent-state-manager', () => ({
+  AgentStateManager: vi.fn(function () {
+    return { getState: vi.fn(), invalidate: vi.fn(), invalidateAll: vi.fn(), setDiscoveredItems: vi.fn(), getDiscoveredItems: vi.fn().mockReturnValue([]), onDidChange: vi.fn(() => ({ dispose: vi.fn() })), dispose: vi.fn() };
+  }),
+}));
+
 vi.mock('../agent-settings', () => ({
   createAgentSettings: vi.fn(() => ({
     get: mockAgentSettingsGet,

--- a/src/__tests__/tree-providers-extra.test.ts
+++ b/src/__tests__/tree-providers-extra.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EditlessTreeProvider, EditlessTreeItem } from '../editless-tree';
+import { AgentStateManager } from '../agent-state-manager';
 import { ThemeIcon, ThemeColor } from 'vscode';
 
 // Mock AgentSettingsManager
@@ -48,7 +49,7 @@ describe('EditlessTreeProvider — Extra Visibility Tests', () => {
     mockAgentSettings.isHidden.mockReturnValue(false);
     mockAgentSettings.getHiddenIds.mockReturnValue([]);
     // Cast to never to bypass strict typing of mock vs real
-    provider = new EditlessTreeProvider(mockAgentSettings as never);
+    provider = new EditlessTreeProvider(new AgentStateManager(mockAgentSettings as never), mockAgentSettings as never);
   });
 
   it('renders hidden agents with dimmed icon and (hidden) description inside group', () => {

--- a/src/__tests__/tree-providers.test.ts
+++ b/src/__tests__/tree-providers.test.ts
@@ -48,6 +48,7 @@ vi.mock('../terminal-manager', () => ({
 import { WorkItemsTreeProvider, WorkItemsTreeItem } from '../work-items-tree';
 import { PRsTreeProvider, PRsTreeItem } from '../prs-tree';
 import { EditlessTreeProvider, EditlessTreeItem } from '../editless-tree';
+import { AgentStateManager } from '../agent-state-manager';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -276,7 +277,7 @@ describe('EditlessTreeProvider — getParent', () => {
       { id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
 
@@ -291,7 +292,7 @@ describe('EditlessTreeProvider — getParent', () => {
       { id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad');
@@ -309,7 +310,7 @@ describe('EditlessTreeProvider — getParent', () => {
       { id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad')!;
@@ -363,7 +364,7 @@ describe('EditlessTreeProvider — getChildren(squad)', () => {
   it('returns terminal sessions + roster category', () => {
     const squads = [{ id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' }];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad')!;
@@ -376,7 +377,7 @@ describe('EditlessTreeProvider — getChildren(squad)', () => {
 
   it('returns empty array for unknown squad id', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     const fakeSquadItem = new EditlessTreeItem('Fake', 'squad', 1, 'nonexistent');
 
     const children = provider.getChildren(fakeSquadItem);
@@ -423,7 +424,7 @@ describe('EditlessTreeProvider — getChildren(category)', () => {
 
   it('returns roster agents for roster category', () => {
     const agentSettings = createMockAgentSettings(testSquads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(testSquads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad')!;
@@ -440,7 +441,7 @@ describe('EditlessTreeProvider — getChildren(category)', () => {
 
   it('returns empty for non-squad non-category element', () => {
     const agentSettings = createMockAgentSettings(testSquads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     const item = new EditlessTreeItem('Random', 'agent');
 
     const children = provider.getChildren(item);
@@ -485,7 +486,7 @@ describe('EditlessTreeProvider — findTerminalItem', () => {
 
   it('returns undefined when no terminal manager', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     const mockTerminal = { name: 'test' } as never;
 
     expect(provider.findTerminalItem(mockTerminal)).toBeUndefined();
@@ -503,7 +504,7 @@ describe('EditlessTreeProvider — findTerminalItem', () => {
       getLastActivityAt: vi.fn().mockReturnValue(undefined),
     };
 
-    const provider = new EditlessTreeProvider(agentSettings as never, mockTerminalMgr as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, mockTerminalMgr as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const mockTerminal = { name: 'untracked' } as never;
 
@@ -524,7 +525,7 @@ describe('EditlessTreeProvider — findTerminalItem', () => {
       getLastActivityAt: vi.fn().mockReturnValue(undefined),
     };
 
-    const provider = new EditlessTreeProvider(agentSettings as never, mockTerminalMgr as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, mockTerminalMgr as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const found = provider.findTerminalItem(mockTerminal);
 
@@ -571,7 +572,7 @@ describe('EditlessTreeProvider — refresh / setDiscoveredItems / invalidate', (
   it('refresh clears cache and fires onDidChangeTreeData', () => {
     const squads = [{ id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' }];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const listener = vi.fn();
     provider.onDidChangeTreeData(listener);
@@ -588,7 +589,7 @@ describe('EditlessTreeProvider — refresh / setDiscoveredItems / invalidate', (
 
   it('setDiscoveredItems updates list and fires event', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     const listener = vi.fn();
     provider.onDidChangeTreeData(listener);
 
@@ -611,7 +612,7 @@ describe('EditlessTreeProvider — refresh / setDiscoveredItems / invalidate', (
       { id: 'squad-b', name: 'Squad B', path: '/b', icon: '🚀', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const listener = vi.fn();
     provider.onDidChangeTreeData(listener);
@@ -662,7 +663,7 @@ describe('EditlessTreeProvider — visibility filtering', () => {
       { id: 'squad-b', name: 'Squad B', path: '/b', icon: '🚀', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads, { isHidden: (id: string) => id === 'squad-a' });
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -683,7 +684,7 @@ describe('EditlessTreeProvider — visibility filtering', () => {
   it('"Hidden" group shown when everything hidden', () => {
     const squads = [{ id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' }];
     const agentSettings = createMockAgentSettings(squads, { isHidden: () => true, getHiddenIds: () => ['squad-a'] });
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -698,7 +699,7 @@ describe('EditlessTreeProvider — visibility filtering', () => {
 
   it('shows default Copilot CLI agent when no squads registered', () => {
     const agentSettings = createMockAgentSettings([], { isHidden: () => false, getHiddenIds: () => [] });
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
 
     const roots = provider.getChildren();
 
@@ -747,7 +748,7 @@ describe('EditlessTreeProvider — default Copilot CLI agent', () => {
       { id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -763,7 +764,7 @@ describe('EditlessTreeProvider — default Copilot CLI agent', () => {
       { id: 'squad-b', name: 'Squad B', path: '/b', icon: '🚀', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -776,7 +777,7 @@ describe('EditlessTreeProvider — default Copilot CLI agent', () => {
 
   it('has contextValue "default-agent" for menu targeting', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
 
     const roots = provider.getChildren();
     const defaultItem = roots.find(r => r.type === 'default-agent');
@@ -787,7 +788,7 @@ describe('EditlessTreeProvider — default Copilot CLI agent', () => {
 
   it('is not affected by agentSettings isHidden', () => {
     const agentSettings = createMockAgentSettings([], { isHidden: () => true, getHiddenIds: () => [] });
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
 
     const roots = provider.getChildren();
     const defaultItem = roots.find(r => r.type === 'default-agent');
@@ -798,7 +799,7 @@ describe('EditlessTreeProvider — default Copilot CLI agent', () => {
 
   it('shows "Generic Copilot agent" description when no sessions', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
 
     const roots = provider.getChildren();
     const defaultItem = roots.find(r => r.type === 'default-agent');
@@ -836,7 +837,7 @@ describe('EditlessTreeProvider — discovered agents', () => {
 
   it('shows discovered agents as root items', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems([
       { id: 'a1', name: 'Bot One', type: 'agent' as const, source: 'workspace' as const, path: '/bots/one.md' },
       { id: 'a2', name: 'Bot Two', type: 'agent' as const, source: 'copilot-dir' as const, path: '/bots/two.agent.md' },
@@ -849,7 +850,7 @@ describe('EditlessTreeProvider — discovered agents', () => {
 
   it('hidden discovered agents appear under collapsible Hidden group', () => {
     const agentSettings = createMockAgentSettings([], { isHidden: (id: string) => id === 'a1' });
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems([
       { id: 'a1', name: 'Bot One', type: 'agent' as const, source: 'workspace' as const, path: '/bots/one.md' },
       { id: 'a2', name: 'Bot Two', type: 'agent' as const, source: 'workspace' as const, path: '/bots/two.md' },
@@ -899,7 +900,7 @@ describe('EditlessTreeProvider — setDiscoveredItems', () => {
 
   it('shows both agents and squads from unified discovery as root items', () => {
     const agentSettings = createMockAgentSettings([]);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems([
       { id: 'agent-1', name: 'Solo Agent', type: 'agent' as const, source: 'workspace' as const, path: '/agents/solo.agent.md', description: 'An agent' },
       { id: 'squad-1', name: 'Team Alpha', type: 'squad' as const, source: 'workspace' as const, path: '/squads/alpha', description: 'A squad', universe: 'acme' },
@@ -963,7 +964,7 @@ describe('EditlessTreeProvider — squad item description', () => {
       getLastActivityAt: vi.fn().mockReturnValue(undefined),
     };
 
-    const provider = new EditlessTreeProvider(agentSettings as never, mockTerminalMgr as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, mockTerminalMgr as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad')!;
@@ -982,7 +983,7 @@ describe('EditlessTreeProvider — squad item description', () => {
       getLastActivityAt: vi.fn().mockReturnValue(undefined),
     };
 
-    const provider = new EditlessTreeProvider(agentSettings as never, mockTerminalMgr as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, mockTerminalMgr as never);
     provider.setDiscoveredItems(toDiscovered(squads));
     const roots = provider.getChildren();
     const squadItem = roots.find(r => r.type === 'squad')!;
@@ -1032,7 +1033,7 @@ describe('EditlessTreeProvider — Tree Item ID Collision Prevention', () => {
       { id: 'squad-b', name: 'Squad B', path: '/projects/beta', icon: '🚀', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -1060,7 +1061,7 @@ describe('EditlessTreeProvider — Tree Item ID Collision Prevention', () => {
       { id: 'squad-a', name: 'Squad A', path: '/projects/alpha', icon: '🤖', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const getRosterIds = () => {
@@ -1085,7 +1086,7 @@ describe('EditlessTreeProvider — Tree Item ID Collision Prevention', () => {
       { id: 'squad-b', name: 'Squad B', path: '/projects/beta', icon: '🚀', universe: 'test' },
     ];
     const agentSettings = createMockAgentSettings(squads);
-    const provider = new EditlessTreeProvider(agentSettings as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const collectAllIds = (item?: EditlessTreeItem): string[] => {
@@ -1172,7 +1173,7 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
 
     const agentSettings = createMockAgentSettings(squads);
     const tm = makeTerminalManager([orphan]);
-    const provider = new EditlessTreeProvider(agentSettings as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -1203,7 +1204,7 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
 
     const agentSettings = createMockAgentSettings(squads);
     const tm = makeTerminalManager([orphan]);
-    const provider = new EditlessTreeProvider(agentSettings as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -1230,7 +1231,7 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
 
     const agentSettings = createMockAgentSettings(squads);
     const tm = makeTerminalManager([resumableOrphan, nonResumableOrphan]);
-    const provider = new EditlessTreeProvider(agentSettings as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(agentSettings as never), agentSettings as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(squads));
 
     const roots = provider.getChildren();
@@ -1302,7 +1303,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
       { id: 'o2', squadId: 'squad-a', agentSessionId: 'sess-2', displayName: 'Test2', labelKey: 'k2', squadName: 'A', squadIcon: '🤖', index: 2, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T2', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
-    const provider = new EditlessTreeProvider(createMockAgentSettings(standaloneSquad) as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings(standaloneSquad) as never), createMockAgentSettings(standaloneSquad) as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(standaloneSquad));
 
     const roots = provider.getChildren();
@@ -1315,7 +1316,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
       { id: 'o1', squadId: 'squad-a', agentSessionId: 'sess-1', displayName: 'Test', labelKey: 'k', squadName: 'A', squadIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
-    const provider = new EditlessTreeProvider(createMockAgentSettings(standaloneSquad) as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings(standaloneSquad) as never), createMockAgentSettings(standaloneSquad) as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(standaloneSquad));
 
     const roots = provider.getChildren();
@@ -1329,7 +1330,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
       { id: 'o1', squadId: 'builtin:copilot-cli', agentSessionId: 'sess-1', displayName: 'CLI', labelKey: 'k', squadName: 'CLI', squadIcon: '', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'CLI', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
-    const provider = new EditlessTreeProvider(createMockAgentSettings([]) as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings([]) as never), createMockAgentSettings([]) as never, tm as never);
 
     const roots = provider.getChildren();
     const defaultItem = roots.find(r => r.type === 'default-agent')!;
@@ -1343,7 +1344,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
       { id: 'o1', squadId: 'builtin:copilot-cli', agentSessionId: 'sess-1', displayName: 'CLI #1', labelKey: 'k', squadName: 'CLI', squadIcon: '', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'CLI', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
-    const provider = new EditlessTreeProvider(createMockAgentSettings([]) as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings([]) as never), createMockAgentSettings([]) as never, tm as never);
 
     const roots = provider.getChildren();
     const defaultItem = roots.find(r => r.type === 'default-agent')!;
@@ -1356,7 +1357,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
 
   it('description has no resumable text when no orphans exist', () => {
     const tm = makeTerminalManager([], []);
-    const provider = new EditlessTreeProvider(createMockAgentSettings(standaloneSquad) as never, tm as never);
+    const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings(standaloneSquad) as never), createMockAgentSettings(standaloneSquad) as never, tm as never);
     provider.setDiscoveredItems(toDiscovered(standaloneSquad));
 
     const roots = provider.getChildren();

--- a/src/agent-state-manager.ts
+++ b/src/agent-state-manager.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { scanSquad } from './scanner';
+import { toAgentTeamConfig, type DiscoveredItem } from './unified-discovery';
+import type { SquadState } from './types';
+import type { AgentSettingsManager } from './agent-settings';
+
+/**
+ * Owns discovered-item state and the per-squad scan cache.
+ * Fires `onDidChange` whenever the data changes so consumers (tree, status bar, etc.) can react.
+ */
+export class AgentStateManager {
+  private _cache = new Map<string, SquadState>();
+  private _discoveredItems: DiscoveredItem[] = [];
+
+  private _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
+
+  constructor(private readonly agentSettings: AgentSettingsManager) {}
+
+  // -- Discovered items -----------------------------------------------------
+
+  setDiscoveredItems(items: DiscoveredItem[]): void {
+    this._discoveredItems = items;
+    this._onDidChange.fire();
+  }
+
+  getDiscoveredItems(): readonly DiscoveredItem[] {
+    return this._discoveredItems;
+  }
+
+  // -- Squad state cache ----------------------------------------------------
+
+  getState(squadId: string): SquadState | undefined {
+    if (!this._cache.has(squadId)) {
+      const disc = this._discoveredItems.find(d => d.id === squadId);
+      if (!disc) return undefined;
+      const settings = this.agentSettings.get(squadId);
+      const cfg = toAgentTeamConfig(disc, settings);
+      this._cache.set(squadId, scanSquad(cfg));
+    }
+    return this._cache.get(squadId);
+  }
+
+  invalidate(squadId: string): void {
+    this._cache.delete(squadId);
+    this._onDidChange.fire();
+  }
+
+  invalidateAll(): void {
+    this._cache.clear();
+    this._onDidChange.fire();
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -1,15 +1,15 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import { scanSquad } from './scanner';
 import { getLocalSquadVersion } from './squad-utils';
 import { getStateIcon, getStateDescription } from './terminal-manager';
 import type { TerminalManager, PersistedTerminalInfo, SessionState } from './terminal-manager';
 import type { SessionLabelManager } from './session-labels';
 import type { SessionContextResolver } from './session-context';
 import type { AgentTeamConfig, SquadState, AgentInfo, SessionContext } from './types';
-import { type DiscoveredItem, toAgentTeamConfig } from './unified-discovery';
+import type { DiscoveredItem } from './unified-discovery';
 import { normalizeSquadName } from './discovery';
 import type { AgentSettingsManager } from './agent-settings';
+import type { AgentStateManager } from './agent-state-manager';
 
 // ---------------------------------------------------------------------------
 // Tree item types
@@ -68,18 +68,18 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   private _onDidChangeTreeData = new vscode.EventEmitter<EditlessTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  private _cache = new Map<string, SquadState>();
-  private _discoveredItems: DiscoveredItem[] = [];
-
   private readonly _terminalSub: vscode.Disposable | undefined;
   private readonly _labelSub: vscode.Disposable | undefined;
+  private readonly _stateSub: vscode.Disposable | undefined;
 
   constructor(
+    private readonly stateManager: AgentStateManager,
     private readonly agentSettings: AgentSettingsManager,
     private readonly terminalManager?: TerminalManager,
     private readonly labelManager?: SessionLabelManager,
     private readonly sessionContextResolver?: SessionContextResolver,
   ) {
+    this._stateSub = stateManager.onDidChange(() => this._onDidChangeTreeData.fire());
     if (terminalManager) {
       this._terminalSub = terminalManager.onDidChange(() => this._onDidChangeTreeData.fire());
     }
@@ -89,28 +89,26 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   }
 
   dispose(): void {
+    this._stateSub?.dispose();
     this._terminalSub?.dispose();
     this._labelSub?.dispose();
     this._onDidChangeTreeData.dispose();
   }
 
   refresh(): void {
-    this._cache.clear();
-    this._onDidChangeTreeData.fire();
+    this.stateManager.invalidateAll();
   }
 
   setDiscoveredItems(items: DiscoveredItem[]): void {
-    this._discoveredItems = items;
-    this._onDidChangeTreeData.fire();
+    this.stateManager.setDiscoveredItems(items);
   }
 
   getDiscoveredItems(): readonly DiscoveredItem[] {
-    return this._discoveredItems;
+    return this.stateManager.getDiscoveredItems();
   }
 
   invalidate(squadId: string): void {
-    this._cache.delete(squadId);
-    this._onDidChangeTreeData.fire();
+    this.stateManager.invalidate(squadId);
   }
 
   findTerminalItem(terminal: vscode.Terminal): EditlessTreeItem | undefined {
@@ -180,8 +178,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     items.push(this.buildDefaultAgentItem());
 
     // Visible agents at top level, hidden agents in collapsible group
-    const visible = this._discoveredItems.filter(i => !this.agentSettings.isHidden(i.id));
-    const hidden = this._discoveredItems.filter(i => this.agentSettings.isHidden(i.id));
+    const visible = this.stateManager.getDiscoveredItems().filter(i => !this.agentSettings.isHidden(i.id));
+    const hidden = this.stateManager.getDiscoveredItems().filter(i => this.agentSettings.isHidden(i.id));
 
     for (const disc of visible) {
       items.push(this.buildDiscoveredRootItem(disc, false));
@@ -389,14 +387,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   // -- Squad children: categories + terminal sessions ---------------------
 
   private getState(squadId: string): SquadState | undefined {
-    if (!this._cache.has(squadId)) {
-      const disc = this._discoveredItems.find(d => d.id === squadId);
-      if (!disc) return undefined;
-      const settings = this.agentSettings.get(squadId);
-      const cfg = toAgentTeamConfig(disc, settings);
-      this._cache.set(squadId, scanSquad(cfg));
-    }
-    return this._cache.get(squadId);
+    return this.stateManager.getState(squadId);
   }
 
   private getSquadChildren(squadId: string, parentItem?: EditlessTreeItem): EditlessTreeItem[] {
@@ -478,7 +469,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   // -- Hidden group children ------------------------------------------------
 
   private getHiddenGroupChildren(parentItem: EditlessTreeItem): EditlessTreeItem[] {
-    const hidden = this._discoveredItems.filter(i => this.agentSettings.isHidden(i.id));
+    const hidden = this.stateManager.getDiscoveredItems().filter(i => this.agentSettings.isHidden(i.id));
     const children = hidden.map(disc => this.buildDiscoveredRootItem(disc, true));
     for (const child of children) {
       child.parent = parentItem;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { createAgentSettings, migrateFromRegistry, type AgentSettings, type AgentSettingsManager } from './agent-settings';
+import { AgentStateManager } from './agent-state-manager';
 import { EditlessTreeProvider } from './editless-tree';
 import { TerminalManager, EDITLESS_INSTRUCTIONS_DIR } from './terminal-manager';
 import { SessionLabelManager } from './session-labels';
@@ -132,7 +133,8 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   terminalManager.setSessionResolver(sessionContextResolver);
 
   // --- Tree view ---------------------------------------------------------
-  const treeProvider = new EditlessTreeProvider(agentSettings, terminalManager, labelManager, sessionContextResolver);
+  const agentStateManager = new AgentStateManager(agentSettings);
+  const treeProvider = new EditlessTreeProvider(agentStateManager, agentSettings, terminalManager, labelManager, sessionContextResolver);
   const treeView = vscode.window.createTreeView('editlessTree', { treeDataProvider: treeProvider });
   context.subscriptions.push(treeView);
   context.subscriptions.push(treeProvider);


### PR DESCRIPTION
## Summary

Closes #395

### Problem
editless-tree.ts mixed state management (_cache, _discoveredItems), UI rendering logic, icon selection, and the default agent definition in a single file.

### Changes

- **New: agent-state-manager.ts** — `AgentStateManager` class that owns:
  - Discovered items cache (`setDiscoveredItems`/`getDiscoveredItems`)
  - Squad state cache (`getState`/`invalidate`/`invalidateAll`)
  - `onDidChange` event emitter for state change notifications
- **editless-tree.ts** — Removed `_cache`, `_discoveredItems`, `scanSquad`/`toAgentTeamConfig` imports. Constructor now takes `AgentStateManager` as first parameter. All state methods delegate to the state manager.
- **extension.ts** — Creates `AgentStateManager` and passes it to `EditlessTreeProvider`  
- **11 new tests** for state manager behavior
- 973 total tests passing (962 baseline + 11 new)