### PR TITLE
feat: add Copilot Sessions tree view for browsing and resuming sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
         {
           "id": "editlessPRs",
           "name": "Pull Requests"
+        },
+        {
+          "id": "editlessSessions",
+          "name": "Sessions"
         }
       ]
     },
@@ -331,6 +335,35 @@
         "title": "Open Task File",
         "category": "EditLess",
         "icon": "$(go-to-file)"
+      },
+      {
+        "command": "editless.resumeCopilotSession",
+        "title": "Resume Session",
+        "category": "EditLess",
+        "icon": "$(play)"
+      },
+      {
+        "command": "editless.dismissSession",
+        "title": "Dismiss Session",
+        "category": "EditLess"
+      },
+      {
+        "command": "editless.refreshSessions",
+        "title": "Refresh Sessions",
+        "category": "EditLess",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "editless.filterSessions",
+        "title": "Filter Sessions",
+        "category": "EditLess",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "editless.clearSessionsFilter",
+        "title": "Clear Filter",
+        "category": "EditLess",
+        "icon": "$(clear-all)"
       }
     ],
     "keybindings": [
@@ -401,6 +434,21 @@
           "command": "editless.configurePRs",
           "when": "view == editlessPRs",
           "group": "navigation@5"
+        },
+        {
+          "command": "editless.refreshSessions",
+          "when": "view == editlessSessions",
+          "group": "navigation@1"
+        },
+        {
+          "command": "editless.filterSessions",
+          "when": "view == editlessSessions",
+          "group": "navigation@2"
+        },
+        {
+          "command": "editless.clearSessionsFilter",
+          "when": "view == editlessSessions && editless.sessionsFiltered",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [
@@ -565,6 +613,16 @@
           "command": "editless.showAgent",
           "when": "view == editlessTree && viewItem == squad-hidden",
           "group": "squad@5"
+        },
+        {
+          "command": "editless.resumeCopilotSession",
+          "when": "view == editlessSessions && viewItem =~ /^copilot-session/",
+          "group": "inline@0"
+        },
+        {
+          "command": "editless.dismissSession",
+          "when": "view == editlessSessions && viewItem =~ /^copilot-session/",
+          "group": "session@1"
         }
       ],
       "commandPalette": [
@@ -706,6 +764,26 @@
         },
         {
           "command": "editless.openTaskFile",
+          "when": "false"
+        },
+        {
+          "command": "editless.resumeCopilotSession",
+          "when": "false"
+        },
+        {
+          "command": "editless.dismissSession",
+          "when": "false"
+        },
+        {
+          "command": "editless.refreshSessions",
+          "when": "false"
+        },
+        {
+          "command": "editless.filterSessions",
+          "when": "false"
+        },
+        {
+          "command": "editless.clearSessionsFilter",
           "when": "false"
         }
       ]

--- a/src/__tests__/auto-refresh.test.ts
+++ b/src/__tests__/auto-refresh.test.ts
@@ -17,11 +17,24 @@ const {
 vi.mock('vscode', () => ({
   window: {
     onDidChangeWindowState: mockOnDidChangeWindowState,
+    createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
   },
   workspace: {
     getConfiguration: mockGetConfiguration,
     onDidChangeConfiguration: mockOnDidChangeConfiguration,
   },
+  TreeItem: class { constructor(public label: string, public collapsibleState?: number) {} },
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: class { constructor(public id: string, public color?: unknown) {} },
+  ThemeColor: class { constructor(public id: string) {} },
+  MarkdownString: class { constructor(public value: string) {} },
+  EventEmitter: class {
+    private listeners: Function[] = [];
+    get event() { return (l: Function) => { this.listeners.push(l); return { dispose: () => {} }; }; }
+    fire(v?: unknown) { this.listeners.forEach(l => l(v)); }
+    dispose() {}
+  },
+  commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
 }));
 
 // Stub remaining module mocks so extension.ts doesn't blow up at import time
@@ -53,6 +66,7 @@ vi.mock('../ado-auth', () => ({ getAdoToken: vi.fn(), promptAdoSignIn: vi.fn(), 
 vi.mock('../ado-client', () => ({ fetchAdoWorkItems: vi.fn(), fetchAdoPRs: vi.fn() }));
 vi.mock('../squad-ui-integration', () => ({ initSquadUiContext: vi.fn(), openSquadUiDashboard: vi.fn() }));
 vi.mock('../team-dir', () => ({ resolveTeamDir: vi.fn() }));
+vi.mock('../copilot-sessions-provider', () => ({ CopilotSessionsProvider: vi.fn(function () { return { refresh: vi.fn(), setTreeView: vi.fn(), filter: {}, dismiss: vi.fn(), onDidChangeTreeData: vi.fn(() => ({ dispose: vi.fn() })) }; }), SessionTreeItem: class { constructor(public label: string) {} } }));
 
 import { initAutoRefresh } from '../extension';
 

--- a/src/__tests__/config-refresh.test.ts
+++ b/src/__tests__/config-refresh.test.ts
@@ -204,6 +204,7 @@ vi.mock('../ado-client', () => ({ fetchAdoWorkItems: vi.fn(), fetchAdoPRs: vi.fn
 vi.mock('../local-tasks-client', () => ({ fetchLocalTasks: vi.fn().mockResolvedValue([]), mapLocalState: vi.fn().mockReturnValue('open') }));
 vi.mock('../squad-ui-integration', () => ({ initSquadUiContext: vi.fn(), openSquadUiDashboard: vi.fn() }));
 vi.mock('../team-dir', () => ({ resolveTeamDir: vi.fn(), resolveTeamMd: vi.fn(), TEAM_DIR_NAMES: ['.squad', '.ai-team'] }));
+vi.mock('../copilot-sessions-provider', () => ({ CopilotSessionsProvider: vi.fn(function () { return { refresh: vi.fn(), setTreeView: vi.fn(), filter: {}, dismiss: vi.fn(), onDidChangeTreeData: vi.fn(() => ({ dispose: vi.fn() })) }; }), SessionTreeItem: class { constructor(public label: string) {} } }));
 vi.mock('../launch-utils', () => ({ launchAndLabel: vi.fn() }));
 
 vi.mock('fs', async (importOriginal) => {

--- a/src/__tests__/copilot-sessions-provider.test.ts
+++ b/src/__tests__/copilot-sessions-provider.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createVscodeMock, ThemeIcon, ThemeColor } from './mocks/vscode-mocks';
+
+vi.mock('vscode', () => createVscodeMock());
+
+import { CopilotSessionsProvider, SessionTreeItem, formatRelativeTime } from '../copilot-sessions-provider';
+import type { CwdIndexEntry, SessionContextResolver } from '../session-context';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResolver(sessions: CwdIndexEntry[] = [], resumable = true, stale = false): SessionContextResolver {
+  return {
+    getAllSessions: vi.fn(() => sessions),
+    isSessionResumable: vi.fn(() => ({ resumable, reason: resumable ? undefined : 'missing workspace.yaml', stale })),
+    clearCache: vi.fn(),
+  } as unknown as SessionContextResolver;
+}
+
+function makeSession(overrides: Partial<CwdIndexEntry> = {}): CwdIndexEntry {
+  return {
+    sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    cwd: '/home/user/project',
+    summary: 'Fix login bug',
+    branch: 'fix-login',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-15T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function recentDate(minutesAgo: number): string {
+  return new Date(Date.now() - minutesAgo * 60_000).toISOString();
+}
+
+function staleDate(): string {
+  return new Date(Date.now() - 15 * 24 * 60 * 60_000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CopilotSessionsProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('session listing', () => {
+    it('returns sessions sorted by updatedAt DESC', () => {
+      const s1 = makeSession({ sessionId: 'aaa', updatedAt: '2025-01-10T00:00:00Z', summary: 'Older' });
+      const s2 = makeSession({ sessionId: 'bbb', updatedAt: '2025-01-20T00:00:00Z', summary: 'Newer' });
+      const resolver = makeResolver([s1, s2]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      expect(children.length).toBe(2);
+      expect(children[0].label).toBe('Newer');
+      expect(children[1].label).toBe('Older');
+    });
+
+    it('uses session ID prefix when no summary', () => {
+      const s = makeSession({ summary: '', sessionId: 'abcdefgh-1234-5678-9012-abcdefabcdef' });
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      expect(children[0].label).toBe('Session abcdefgh');
+    });
+
+    it('shows CWD as description', () => {
+      const s = makeSession({ cwd: '/home/user/myproject' });
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      expect(children[0].description).toBe('/home/user/myproject');
+    });
+
+    it('sets session entry on tree item', () => {
+      const s = makeSession();
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      expect(children[0].sessionEntry).toBe(s);
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows "No sessions found" message when empty', () => {
+      const resolver = makeResolver([]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      expect(children.length).toBe(1);
+      expect(children[0].label).toBe('No sessions found');
+      expect(children[0].contextValue).toBe('empty');
+    });
+  });
+
+  describe('stale sessions', () => {
+    it('shows history icon and stale contextValue for old sessions', () => {
+      const s = makeSession({ updatedAt: staleDate() });
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      const icon = children[0].iconPath as ThemeIcon;
+      expect(icon.id).toBe('history');
+      expect(icon.color).toBeInstanceOf(ThemeColor);
+      expect(children[0].contextValue).toBe('copilot-session-stale');
+    });
+
+    it('shows terminal icon for recent sessions', () => {
+      const s = makeSession({ updatedAt: recentDate(5) });
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      const children = provider.getChildren();
+      const icon = children[0].iconPath as ThemeIcon;
+      expect(icon.id).toBe('terminal');
+      expect(children[0].contextValue).toBe('copilot-session');
+    });
+  });
+
+  describe('filter by workspace', () => {
+    it('only shows matching sessions', () => {
+      const s1 = makeSession({ sessionId: 'aaa', cwd: '/home/user/project-a', summary: 'A' });
+      const s2 = makeSession({ sessionId: 'bbb', cwd: '/home/user/project-b', summary: 'B' });
+      const resolver = makeResolver([s1, s2]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      provider.filter = { workspace: '/home/user/project-a' };
+      const children = provider.getChildren();
+      expect(children.length).toBe(1);
+      expect(children[0].label).toBe('A');
+    });
+
+    it('filters case-insensitively', () => {
+      const s = makeSession({ cwd: 'C:\\Users\\Me\\Project' });
+      const resolver = makeResolver([s]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      provider.filter = { workspace: 'c:\\users\\me\\project' };
+      const children = provider.getChildren();
+      expect(children.length).toBe(1);
+    });
+  });
+
+  describe('filter by squad', () => {
+    it('filters sessions by squad name in summary or branch', () => {
+      const s1 = makeSession({ sessionId: 'aaa', summary: 'squad alpha work', branch: 'main' });
+      const s2 = makeSession({ sessionId: 'bbb', summary: 'other', branch: 'feat/beta' });
+      const resolver = makeResolver([s1, s2]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      provider.filter = { squad: 'alpha' };
+      const children = provider.getChildren();
+      expect(children.length).toBe(1);
+      expect(children[0].label).toBe('squad alpha work');
+    });
+  });
+
+  describe('dismiss', () => {
+    it('hides dismissed sessions', () => {
+      const s1 = makeSession({ sessionId: 'aaa', summary: 'A' });
+      const s2 = makeSession({ sessionId: 'bbb', summary: 'B' });
+      const resolver = makeResolver([s1, s2]);
+      const provider = new CopilotSessionsProvider(resolver);
+
+      provider.dismiss('aaa');
+      const children = provider.getChildren();
+      expect(children.length).toBe(1);
+      expect(children[0].label).toBe('B');
+    });
+  });
+
+  describe('refresh', () => {
+    it('clears resolver cache and fires change event', () => {
+      const resolver = makeResolver([]);
+      const provider = new CopilotSessionsProvider(resolver);
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+
+      provider.refresh();
+      expect(resolver.clearCache).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+
+  describe('getParent', () => {
+    it('returns undefined (flat list)', () => {
+      const resolver = makeResolver([]);
+      const provider = new CopilotSessionsProvider(resolver);
+      expect(provider.getParent()).toBeUndefined();
+    });
+  });
+
+  describe('getChildren with element', () => {
+    it('returns empty array for child elements', () => {
+      const resolver = makeResolver([]);
+      const provider = new CopilotSessionsProvider(resolver);
+      const item = new SessionTreeItem('test');
+      expect(provider.getChildren(item)).toEqual([]);
+    });
+  });
+});
+
+describe('formatRelativeTime', () => {
+  it('returns empty for empty string', () => {
+    expect(formatRelativeTime('')).toBe('');
+  });
+
+  it('returns "just now" for recent times', () => {
+    expect(formatRelativeTime(new Date().toISOString())).toBe('just now');
+  });
+
+  it('returns minutes for times under an hour', () => {
+    const d = new Date(Date.now() - 30 * 60_000).toISOString();
+    expect(formatRelativeTime(d)).toBe('30m ago');
+  });
+
+  it('returns hours for times under a day', () => {
+    const d = new Date(Date.now() - 3 * 60 * 60_000).toISOString();
+    expect(formatRelativeTime(d)).toBe('3h ago');
+  });
+
+  it('returns days for older times', () => {
+    const d = new Date(Date.now() - 5 * 24 * 60 * 60_000).toISOString();
+    expect(formatRelativeTime(d)).toBe('5d ago');
+  });
+});

--- a/src/__tests__/extension-commands-extra.test.ts
+++ b/src/__tests__/extension-commands-extra.test.ts
@@ -116,6 +116,7 @@ vi.mock('../ado-auth', () => ({ setAdoAuthOutput: vi.fn() }));
 vi.mock('../ado-client', () => ({}));
 vi.mock('../local-tasks-client', () => ({ fetchLocalTasks: vi.fn().mockResolvedValue([]), mapLocalState: vi.fn().mockReturnValue('open') }));
 vi.mock('../launch-utils', () => ({}));
+vi.mock('../copilot-sessions-provider', () => ({ CopilotSessionsProvider: vi.fn(function () { return { refresh: vi.fn(), setTreeView: vi.fn(), filter: {}, dismiss: vi.fn(), onDidChangeTreeData: vi.fn(() => ({ dispose: vi.fn() })) }; }), SessionTreeItem: class { constructor(public label: string) {} } }));
 
 import { createAgentSettings } from '../agent-settings';
 import { EditlessTreeProvider } from '../editless-tree';

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -450,6 +450,7 @@ vi.mock('../team-dir', () => ({
   resolveTeamMd: vi.fn(),
   TEAM_DIR_NAMES: ['.squad', '.ai-team'],
 }));
+vi.mock('../copilot-sessions-provider', () => ({ CopilotSessionsProvider: vi.fn(function () { return { refresh: vi.fn(), setTreeView: vi.fn(), filter: {}, dismiss: vi.fn(), onDidChangeTreeData: vi.fn(() => ({ dispose: vi.fn() })) }; }), SessionTreeItem: class { constructor(public label: string) {} } }));
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();

--- a/src/copilot-sessions-provider.ts
+++ b/src/copilot-sessions-provider.ts
@@ -1,0 +1,134 @@
+import * as vscode from 'vscode';
+import type { SessionContextResolver, CwdIndexEntry } from './session-context';
+
+/** Format a date string as relative time ("5m ago", "2h ago", "3d ago"). */
+export function formatRelativeTime(dateStr: string): string {
+  if (!dateStr) return '';
+  const ms = Date.now() - new Date(dateStr).getTime();
+  if (Number.isNaN(ms) || ms < 0) return '';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export interface SessionsFilter {
+  squad?: string;
+  workspace?: string;
+}
+
+export class SessionTreeItem extends vscode.TreeItem {
+  sessionEntry?: CwdIndexEntry;
+}
+
+export class CopilotSessionsProvider implements vscode.TreeDataProvider<SessionTreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<SessionTreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private _dismissed = new Set<string>();
+  private _filter: SessionsFilter = {};
+  private _treeView?: vscode.TreeView<SessionTreeItem>;
+  private _resolver: SessionContextResolver;
+
+  constructor(resolver: SessionContextResolver) {
+    this._resolver = resolver;
+  }
+
+  get filter(): SessionsFilter { return this._filter; }
+
+  set filter(value: SessionsFilter) {
+    this._filter = value;
+    this._updateDescription();
+    this.refresh();
+  }
+
+  setTreeView(view: vscode.TreeView<SessionTreeItem>): void {
+    this._treeView = view;
+    this._updateDescription();
+  }
+
+  refresh(): void {
+    this._resolver.clearCache();
+    this._onDidChangeTreeData.fire();
+  }
+
+  dismiss(sessionId: string): void {
+    this._dismissed.add(sessionId);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: SessionTreeItem): SessionTreeItem {
+    return element;
+  }
+
+  getChildren(element?: SessionTreeItem): SessionTreeItem[] {
+    if (element) return [];
+
+    let sessions = this._resolver.getAllSessions();
+
+    // Apply filters
+    if (this._filter.workspace) {
+      const wsLower = this._filter.workspace.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+      sessions = sessions.filter(s => {
+        const norm = s.cwd.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+        return norm === wsLower || norm.startsWith(wsLower + '/');
+      });
+    }
+    if (this._filter.squad) {
+      const sq = this._filter.squad.toLowerCase();
+      sessions = sessions.filter(s => s.branch.toLowerCase().includes(sq) || s.summary.toLowerCase().includes(sq));
+    }
+
+    // Remove dismissed
+    sessions = sessions.filter(s => !this._dismissed.has(s.sessionId));
+
+    if (sessions.length === 0) {
+      const item = new SessionTreeItem('No sessions found');
+      item.contextValue = 'empty';
+      return [item];
+    }
+
+    // Sort by updatedAt DESC
+    sessions.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+    const staleDays = 14;
+    return sessions.map(s => {
+      const isStale = this._isStale(s, staleDays);
+      const label = s.summary || `Session ${s.sessionId.substring(0, 8)}`;
+      const item = new SessionTreeItem(label);
+      item.sessionEntry = s;
+      item.description = s.cwd;
+      item.tooltip = new vscode.MarkdownString(
+        `**${label}**\n\nCWD: ${s.cwd}\nBranch: ${s.branch || '—'}\nUpdated: ${formatRelativeTime(s.updatedAt)}`,
+      );
+      item.iconPath = new vscode.ThemeIcon(
+        isStale ? 'history' : 'terminal',
+        isStale ? new vscode.ThemeColor('disabledForeground') : undefined,
+      );
+      item.contextValue = isStale ? 'copilot-session-stale' : 'copilot-session';
+      item.id = s.sessionId;
+      return item;
+    });
+  }
+
+  getParent(): undefined {
+    return undefined;
+  }
+
+  private _isStale(entry: CwdIndexEntry, days: number): boolean {
+    if (!entry.updatedAt) return false;
+    const ms = Date.now() - new Date(entry.updatedAt).getTime();
+    return ms > days * 24 * 60 * 60 * 1000;
+  }
+
+  private _updateDescription(): void {
+    if (!this._treeView) return;
+    const parts: string[] = [];
+    if (this._filter.workspace) parts.push(`cwd: ${this._filter.workspace}`);
+    if (this._filter.squad) parts.push(`squad: ${this._filter.squad}`);
+    this._treeView.description = parts.length > 0 ? parts.join(', ') : undefined;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import type { AgentTeamConfig } from './types';
 import { SquadWatcher } from './watcher';
 import { EditlessStatusBar } from './status-bar';
 import { SessionContextResolver } from './session-context';
+import { CopilotSessionsProvider } from './copilot-sessions-provider';
 
 import { initSquadUiContext } from './squad-ui-integration';
 import { TEAM_DIR_NAMES } from './team-dir';
@@ -150,6 +151,77 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   const prsView = vscode.window.createTreeView('editlessPRs', { treeDataProvider: prsProvider });
   prsProvider.setTreeView(prsView);
   context.subscriptions.push(prsView);
+
+  // --- Sessions tree view ----------------------------------------------------
+  const sessionsProvider = new CopilotSessionsProvider(sessionContextResolver);
+  const sessionsView = vscode.window.createTreeView('editlessSessions', { treeDataProvider: sessionsProvider });
+  sessionsProvider.setTreeView(sessionsView);
+  context.subscriptions.push(sessionsView);
+
+  // Sessions tree commands
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.resumeCopilotSession', async (item: import('./copilot-sessions-provider').SessionTreeItem) => {
+      const entry = item?.sessionEntry;
+      if (!entry) return;
+      const check = sessionContextResolver.isSessionResumable(entry.sessionId);
+      if (!check.resumable) {
+        vscode.window.showWarningMessage(`Cannot resume session: ${check.reason}`);
+        return;
+      }
+      if (check.stale) {
+        const proceed = await vscode.window.showWarningMessage(
+          `This session hasn't been updated in over ${SessionContextResolver.STALE_SESSION_DAYS} days. Resume anyway?`,
+          'Resume', 'Cancel',
+        );
+        if (proceed !== 'Resume') return;
+      }
+      const { buildCopilotCommand } = await import('./copilot-cli-builder');
+      const launchCmd = buildCopilotCommand({ resume: entry.sessionId });
+      const displayName = entry.summary ? `↩ ${entry.summary}`.slice(0, 50) : `↩ ${entry.sessionId.slice(0, 8)}`;
+      const terminal = vscode.window.createTerminal({
+        name: displayName,
+        cwd: entry.cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '',
+        isTransient: true,
+        iconPath: new vscode.ThemeIcon('history'),
+      });
+      terminal.sendText(launchCmd);
+      terminal.show(false);
+    }),
+    vscode.commands.registerCommand('editless.dismissSession', (item: import('./copilot-sessions-provider').SessionTreeItem) => {
+      const entry = item?.sessionEntry;
+      if (entry) sessionsProvider.dismiss(entry.sessionId);
+    }),
+    vscode.commands.registerCommand('editless.refreshSessions', () => {
+      sessionsProvider.refresh();
+    }),
+    vscode.commands.registerCommand('editless.filterSessions', async () => {
+      const pick = await vscode.window.showQuickPick(
+        [
+          { label: 'Filter by workspace CWD', value: 'workspace' },
+          { label: 'Filter by squad name', value: 'squad' },
+        ],
+        { placeHolder: 'Select filter type' },
+      );
+      if (!pick) return;
+      if (pick.value === 'workspace') {
+        const cwd = await vscode.window.showInputBox({ prompt: 'Enter workspace CWD path to filter by' });
+        if (cwd !== undefined) {
+          sessionsProvider.filter = { ...sessionsProvider.filter, workspace: cwd || undefined };
+          vscode.commands.executeCommand('setContext', 'editless.sessionsFiltered', true);
+        }
+      } else {
+        const squad = await vscode.window.showInputBox({ prompt: 'Enter squad name to filter by' });
+        if (squad !== undefined) {
+          sessionsProvider.filter = { ...sessionsProvider.filter, squad: squad || undefined };
+          vscode.commands.executeCommand('setContext', 'editless.sessionsFiltered', true);
+        }
+      }
+    }),
+    vscode.commands.registerCommand('editless.clearSessionsFilter', () => {
+      sessionsProvider.filter = {};
+      vscode.commands.executeCommand('setContext', 'editless.sessionsFiltered', false);
+    }),
+  );
 
   // Reconcile persisted terminal sessions with live terminals after reload.
   // Orphaned sessions appear in the tree view — users can resume individually.


### PR DESCRIPTION
## Summary

Closes #329

### New Feature
New **Sessions** tree view in the EditLess sidebar showing all Copilot CLI sessions from `~/.copilot/session-state/`.

### Changes

- **New: copilot-sessions-provider.ts** — `CopilotSessionsProvider` tree data provider with:
  - Session listing sorted by last-updated (most recent first)
  - Session summary, CWD, relative time display
  - Stale session detection (>14 days) with dimmed icons
  - Filter by workspace CWD or squad name
  - Dismiss stale sessions
  - Pre-resume validation via `isSessionResumable()`  
- **package.json** — Added `editlessSessions` view, 5 commands (resume, dismiss, refresh, filter, clear filter), view/title and context menus
- **extension.ts** — Wired up provider, tree view, and command handlers with resume validation
- **19 new tests** covering listing, sorting, empty state, stale detection, filtering, dismiss
- 981 total tests passing (962 baseline + 19 new)