### PR TITLE
refactor: rename squad → agent for generic functions and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,37 +454,37 @@
       "view/item/context": [
         {
           "command": "editless.launchSession",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden|^agent|^default-agent$/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden|^agent|^default-agent$/",
           "group": "inline@0"
         },
         {
           "command": "editless.launchSession",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden|^agent|^default-agent$/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden|^agent|^default-agent$/",
           "group": "session@0"
         },
         {
           "command": "editless.resumeSession",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden|^agent|^default-agent$/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden|^agent|^default-agent$/",
           "group": "session@1"
         },
         {
           "command": "editless.renameSquad",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden/",
           "group": "squad@1"
         },
         {
           "command": "editless.changeModel",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden/",
           "group": "squad@2"
         },
         {
           "command": "editless.goToSquadSettings",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden/",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden/",
           "group": "squad@3"
         },
         {
           "command": "editless.openInSquadUi",
-          "when": "view == editlessTree && viewItem =~ /^squad|^squad-hidden/ && editless.squadUiSupportsDeepLink",
+          "when": "view == editlessTree && viewItem =~ /^squad|^agent-hidden/ && editless.squadUiSupportsDeepLink",
           "group": "squad@4"
         },
         {
@@ -611,7 +611,7 @@
         },
         {
           "command": "editless.showAgent",
-          "when": "view == editlessTree && viewItem == squad-hidden",
+          "when": "view == editlessTree && viewItem == agent-hidden",
           "group": "squad@5"
         },
         {

--- a/src/__integration__/persistence.test.ts
+++ b/src/__integration__/persistence.test.ts
@@ -117,9 +117,9 @@ suite('Session Persistence (integration)', () => {
     assert.strictEqual(entry.rebootCount, 0, 'New session rebootCount should be 0');
 
     // Validate squad identity echoes config
-    assert.strictEqual(entry.squadId, config.id);
-    assert.strictEqual(entry.squadName, config.name);
-    assert.strictEqual(entry.squadIcon, config.icon);
+    assert.strictEqual(entry.agentId, config.id);
+    assert.strictEqual(entry.agentName, config.name);
+    assert.strictEqual(entry.agentIcon, config.icon);
   });
 
   // -----------------------------------------------------------------------
@@ -146,17 +146,17 @@ suite('Session Persistence (integration)', () => {
     assert.ok(persisted, 'Should have persisted data');
     assert.strictEqual(persisted.length, 2, 'Should have two persisted sessions');
 
-    const alphaEntry = persisted.find((e: Record<string, unknown>) => e.squadId === 'test-squad-alpha');
-    const betaEntry = persisted.find((e: Record<string, unknown>) => e.squadId === 'test-squad-beta');
+    const alphaEntry = persisted.find((e: Record<string, unknown>) => e.agentId === 'test-squad-alpha');
+    const betaEntry = persisted.find((e: Record<string, unknown>) => e.agentId === 'test-squad-beta');
 
     assert.ok(alphaEntry, 'Should have an entry for alpha squad');
     assert.ok(betaEntry, 'Should have an entry for beta squad');
 
-    assert.strictEqual(alphaEntry.squadName, 'Alpha Squad');
-    assert.strictEqual(alphaEntry.squadIcon, '🅰️');
+    assert.strictEqual(alphaEntry.agentName, 'Alpha Squad');
+    assert.strictEqual(alphaEntry.agentIcon, '🅰️');
 
-    assert.strictEqual(betaEntry.squadName, 'Beta Squad');
-    assert.strictEqual(betaEntry.squadIcon, '🅱️');
+    assert.strictEqual(betaEntry.agentName, 'Beta Squad');
+    assert.strictEqual(betaEntry.agentIcon, '🅱️');
 
     // IDs should be unique
     assert.notStrictEqual(alphaEntry.id, betaEntry.id, 'Session IDs should be unique');

--- a/src/__tests__/extension-commands-extra.test.ts
+++ b/src/__tests__/extension-commands-extra.test.ts
@@ -136,7 +136,7 @@ describe('Extra Extension Commands', () => {
     const handler = mockCommands['editless.hideAgent'];
     expect(handler).toBeDefined();
 
-    const item = { squadId: 'squad-1', type: 'squad-hidden' };
+    const item = { squadId: 'squad-1', type: 'agent-hidden' };
     handler(item);
 
     expect(mockAgentSettings.show).toHaveBeenCalledWith('squad-1');
@@ -155,7 +155,7 @@ describe('Extra Extension Commands', () => {
 
   it('editless.hideAgent should work with item.id if squadId is missing', () => {
     const handler = mockCommands['editless.hideAgent'];
-    const item = { id: 'agent-1', type: 'squad-hidden' }; // EditlessTreeItem has id
+    const item = { id: 'agent-1', type: 'agent-hidden' }; // EditlessTreeItem has id
     handler(item);
 
     expect(mockAgentSettings.show).toHaveBeenCalledWith('agent-1');

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -662,8 +662,8 @@ describe('extension command handlers', () => {
       expect(mockAgentSettingsHide).toHaveBeenCalledWith('my-agent');
     });
 
-    it('should show agent when item type is squad-hidden (toggle)', () => {
-      const item = new MockEditlessTreeItem('Alpha', 'squad-hidden', 0, 'squad-1');
+    it('should show agent when item type is agent-hidden (toggle)', () => {
+      const item = new MockEditlessTreeItem('Alpha', 'agent-hidden', 0, 'squad-1');
       getHandler('editless.hideAgent')(item);
       expect(mockAgentSettingsShow).toHaveBeenCalledWith('squad-1');
       expect(mockTreeRefresh).toHaveBeenCalled();
@@ -755,7 +755,7 @@ describe('extension command handlers', () => {
 
   describe('editless.relaunchSession', () => {
     it('should relaunch from persisted entry on tree item', () => {
-      const entry = { id: 't-1', squadId: 'squad-1', displayName: 'Agent' };
+      const entry = { id: 't-1', agentId: 'squad-1', displayName: 'Agent' };
       const item = new MockEditlessTreeItem('Orphan', 'orphan', 0);
       item.persistedEntry = entry;
 
@@ -779,7 +779,7 @@ describe('extension command handlers', () => {
 
   describe('editless.dismissOrphan', () => {
     it('should dismiss orphan from persisted entry', () => {
-      const entry = { id: 't-1', squadId: 'squad-1', displayName: 'Dead' };
+      const entry = { id: 't-1', agentId: 'squad-1', displayName: 'Dead' };
       const item = new MockEditlessTreeItem('Orphan', 'orphan', 0);
       item.persistedEntry = entry;
 
@@ -851,7 +851,7 @@ describe('extension command handlers', () => {
       mockGetLabelKey.mockReturnValue('squad-1:0');
       mockGetLabel.mockReturnValue(undefined);
       mockGetDisplayName.mockReturnValue('Agent');
-      mockGetTerminalInfo.mockReturnValue({ squadIcon: '🚀' });
+      mockGetTerminalInfo.mockReturnValue({ agentIcon: '🚀' });
       mockShowInputBox.mockResolvedValue('My Agent');
       mockExecuteCommand.mockResolvedValue(undefined);
 
@@ -869,7 +869,7 @@ describe('extension command handlers', () => {
       item.terminal = terminal;
 
       mockGetLabelKey.mockReturnValue('squad-1:0');
-      mockGetTerminalInfo.mockReturnValue({ squadIcon: '🚀' });
+      mockGetTerminalInfo.mockReturnValue({ agentIcon: '🚀' });
       mockShowInputBox.mockResolvedValue('Renamed');
       mockExecuteCommand.mockResolvedValue(undefined);
 
@@ -886,7 +886,7 @@ describe('extension command handlers', () => {
       mockActiveTerminalRef.current = terminal;
 
       mockGetLabelKey.mockReturnValue('squad-1:0');
-      mockGetTerminalInfo.mockReturnValue({ squadIcon: '🚀' });
+      mockGetTerminalInfo.mockReturnValue({ agentIcon: '🚀' });
       mockShowInputBox.mockResolvedValue('Renamed');
       mockExecuteCommand.mockResolvedValue(undefined);
 
@@ -905,7 +905,7 @@ describe('extension command handlers', () => {
       ]);
       mockGetLabel.mockReturnValue(undefined);
       mockGetDisplayName.mockReturnValue('Agent');
-      mockGetTerminalInfo.mockReturnValue({ squadIcon: '🚀' });
+      mockGetTerminalInfo.mockReturnValue({ agentIcon: '🚀' });
       mockShowQuickPick.mockResolvedValue({
         label: 'Agent',
         terminal,

--- a/src/__tests__/terminal-manager.test.ts
+++ b/src/__tests__/terminal-manager.test.ts
@@ -123,9 +123,9 @@ function makePersistedEntry(overrides: Partial<PersistedTerminalInfo> = {}): Per
     id: 'test-squad-1234-1',
     labelKey: 'terminal:test-squad-1234-1',
     displayName: '🧪 Test Squad #1',
-    squadId: 'test-squad',
-    squadName: 'Test Squad',
-    squadIcon: '🧪',
+    agentId: 'test-squad',
+    agentName: 'Test Squad',
+    agentIcon: '🧪',
     index: 1,
     createdAt: '2026-02-16T00:00:00.000Z',
     terminalName: '🧪 Test Squad #1',
@@ -204,9 +204,9 @@ describe('TerminalManager', () => {
         'editless.terminalSessions',
         expect.arrayContaining([
           expect.objectContaining({
-            squadId: 'test-squad',
-            squadName: 'Test Squad',
-            squadIcon: '🧪',
+            agentId: 'test-squad',
+            agentName: 'Test Squad',
+            agentIcon: '🧪',
             index: 1,
             terminalName: '🧪 Test Squad #1',
           }),
@@ -248,7 +248,7 @@ describe('TerminalManager', () => {
       const all = mgr.getAllTerminals();
       expect(all).toHaveLength(1);
       expect(all[0].terminal).toBe(liveTerminal);
-      expect(all[0].info.squadId).toBe('test-squad');
+      expect(all[0].info.agentId).toBe('test-squad');
       expect(all[0].info.index).toBe(1);
     });
   });
@@ -440,14 +440,14 @@ describe('TerminalManager', () => {
       expect(info).toBeDefined();
       expect(info!.displayName).toBe('My Custom Name');
       // squadIcon must be preserved
-      expect(info!.squadIcon).toBe('🧪');
+      expect(info!.agentIcon).toBe('🧪');
 
       expect(ctx.workspaceState.update).toHaveBeenCalledWith(
         'editless.terminalSessions',
         expect.arrayContaining([
           expect.objectContaining({
             displayName: 'My Custom Name',
-            squadIcon: '🧪',
+            agentIcon: '🧪',
           }),
         ]),
       );
@@ -497,7 +497,7 @@ describe('TerminalManager', () => {
 
       mgr.reconcile();
 
-      const forSquad = mgr.getTerminalsForSquad('test-squad');
+      const forSquad = mgr.getTerminalsForAgent('test-squad');
       expect(forSquad).toHaveLength(2);
 
       const indices = forSquad.map(t => t.info.index).sort();
@@ -610,7 +610,7 @@ describe('TerminalManager', () => {
 
       const info = mgr.getTerminalInfo(liveTerminal);
       expect(info).toBeDefined();
-      expect(info!.squadId).toBe('test-squad');
+      expect(info!.agentId).toBe('test-squad');
 
       const orphans = mgr.getOrphanedSessions();
       expect(orphans.find(e => e.id === 'orphan-rematch-1')).toBeUndefined();
@@ -669,9 +669,9 @@ describe('TerminalManager', () => {
     it('should assign correct squad association from the orphaned entry', () => {
       const orphanEntry = makePersistedEntry({
         id: 'orphan-relaunch-2',
-        squadId: 'my-squad',
-        squadName: 'My Squad',
-        squadIcon: '🚀',
+        agentId: 'my-squad',
+        agentName: 'My Squad',
+        agentIcon: '🚀',
         terminalName: '🚀 My Squad #1',
         displayName: '🚀 My Squad #1',
       });
@@ -684,9 +684,9 @@ describe('TerminalManager', () => {
       expect(terminal).toBeDefined();
       const info = mgr.getTerminalInfo(terminal!);
       expect(info).toBeDefined();
-      expect(info!.squadId).toBe('my-squad');
-      expect(info!.squadName).toBe('My Squad');
-      expect(info!.squadIcon).toBe('🚀');
+      expect(info!.agentId).toBe('my-squad');
+      expect(info!.agentName).toBe('My Squad');
+      expect(info!.agentIcon).toBe('🚀');
     });
 
     it('should remove the orphaned entry from orphan list after re-launch', () => {
@@ -1725,11 +1725,11 @@ describe('TerminalManager', () => {
     it('should restore multiple squads with correct association after reload', () => {
       // Pre-seed saved state with two squads
       const alphaEntry = makePersistedEntry({
-        id: 'alpha-1', squadId: 'squad-alpha', squadName: 'Alpha', squadIcon: '🅰️',
+        id: 'alpha-1', agentId: 'squad-alpha', agentName: 'Alpha', agentIcon: '🅰️',
         terminalName: '🅰️ Alpha #1', displayName: '🅰️ Alpha #1', originalName: '🅰️ Alpha #1',
       });
       const betaEntry = makePersistedEntry({
-        id: 'beta-1', squadId: 'squad-beta', squadName: 'Beta', squadIcon: '🅱️',
+        id: 'beta-1', agentId: 'squad-beta', agentName: 'Beta', agentIcon: '🅱️',
         terminalName: '🅱️ Beta #1', displayName: '🅱️ Beta #1', originalName: '🅱️ Beta #1',
       });
       // Simulate live terminals that survived the reload
@@ -1741,7 +1741,7 @@ describe('TerminalManager', () => {
 
       const all = mgr.getAllTerminals();
       expect(all).toHaveLength(2);
-      expect(all.map(t => t.info.squadId).sort()).toEqual(['squad-alpha', 'squad-beta']);
+      expect(all.map(t => t.info.agentId).sort()).toEqual(['squad-alpha', 'squad-beta']);
     });
 
     it('should mark entries as orphaned when terminals are gone (close/reopen)', () => {
@@ -1753,13 +1753,13 @@ describe('TerminalManager', () => {
 
       const orphans = mgr.getOrphanedSessions();
       expect(orphans).toHaveLength(1);
-      expect(orphans[0].squadId).toBe('test-squad');
+      expect(orphans[0].agentId).toBe('test-squad');
     });
 
     it('should persist squadPath from config and carry it through reconcile', () => {
       const entry = makePersistedEntry({
         terminalName: '🧪 Test Squad #1',
-        squadPath: '/home/user/project',
+        agentPath: '/home/user/project',
       });
       const liveTerminal = makeMockTerminal('🧪 Test Squad #1');
       mockTerminals.push(liveTerminal);
@@ -1769,7 +1769,7 @@ describe('TerminalManager', () => {
       mgr.reconcile();
 
       const all = mgr.getAllTerminals();
-      expect(all[0].info.squadPath).toBe('/home/user/project');
+      expect(all[0].info.agentPath).toBe('/home/user/project');
     });
 
     it('should recover session ID through persist/orphan/relaunch cycle', () => {
@@ -1797,7 +1797,7 @@ describe('TerminalManager', () => {
         id: 'relaunch-cwd-1',
         terminalName: '🧪 No Match',
         displayName: '🧪 Test Squad #1',
-        squadPath: '/project/dir',
+        agentPath: '/project/dir',
         launchCommand: 'copilot chat',
       });
       const ctx = makeMockContext([orphanEntry]);
@@ -2500,12 +2500,12 @@ describe('TerminalManager', () => {
         labelKey: 'terminal:legacy-1',
         displayName: 'Legacy Terminal',
         originalName: 'Legacy Terminal',
-        squadId: config.id,
-        squadName: config.name,
-        squadIcon: config.icon,
+        agentId: config.id,
+        agentName: config.name,
+        agentIcon: config.icon,
         index: 1,
         createdAt: new Date(),
-        squadPath: config.path,
+        agentPath: config.path,
       };
       (mgr as any)._terminals.set(terminal, info);
 
@@ -2611,7 +2611,7 @@ describe('TerminalManager', () => {
       // Simulate a persisted entry with index 2 that has mismatched names
       const entry = makePersistedEntry({
         id: 'idx-match-2',
-        squadId: 'idx-squad',
+        agentId: 'idx-squad',
         index: 2,
         terminalName: 'shell-mangled-name',
         displayName: 'shell-mangled-name',
@@ -3021,7 +3021,7 @@ describe('TerminalManager', () => {
       const ctx = makeMockContext();
       const mgr = new TerminalManager(ctx);
       const entry = makePersistedEntry({
-        squadPath: '/home/user/.copilot/agents/my-agent',
+        agentPath: '/home/user/.copilot/agents/my-agent',
         launchCommand: 'copilot --agent my-agent',
         agentSessionId: 'session-123',
       });
@@ -3076,12 +3076,12 @@ describe('TerminalManager', () => {
 
   describe('registerExternalTerminal', () => {
     const defaultMetadata = {
-      squadId: 'ext-squad',
-      squadName: 'External Squad',
-      squadIcon: '🔌',
+      agentId: 'ext-squad',
+      agentName: 'External Squad',
+      agentIcon: '🔌',
       agentSessionId: 'session-abc-123',
       launchCommand: 'copilot-agent --resume session-abc-123',
-      squadPath: '/tmp/ext-squad',
+      agentPath: '/tmp/ext-squad',
     };
 
     it('should register terminal with correct metadata', () => {
@@ -3093,14 +3093,14 @@ describe('TerminalManager', () => {
 
       const info = mgr.getTerminalInfo(terminal);
       expect(info).toBeDefined();
-      expect(info!.squadId).toBe('ext-squad');
-      expect(info!.squadName).toBe('External Squad');
-      expect(info!.squadIcon).toBe('🔌');
+      expect(info!.agentId).toBe('ext-squad');
+      expect(info!.agentName).toBe('External Squad');
+      expect(info!.agentIcon).toBe('🔌');
       expect(info!.displayName).toBe('🔌 External Squad #1');
       expect(info!.originalName).toBe('🔌 External Squad #1');
       expect(info!.agentSessionId).toBe('session-abc-123');
       expect(info!.launchCommand).toBe('copilot-agent --resume session-abc-123');
-      expect(info!.squadPath).toBe('/tmp/ext-squad');
+      expect(info!.agentPath).toBe('/tmp/ext-squad');
       expect(info!.index).toBe(1);
       expect(info!.createdAt).toBeInstanceOf(Date);
     });
@@ -3140,7 +3140,7 @@ describe('TerminalManager', () => {
 
       const info = mgr.getTerminalInfo(terminal);
       expect(info).toBeDefined();
-      expect(info!.squadId).toBe('ext-squad');
+      expect(info!.agentId).toBe('ext-squad');
     });
 
     it('should not create session watcher when agentSessionId is undefined', () => {
@@ -3212,9 +3212,9 @@ describe('TerminalManager', () => {
         'editless.terminalSessions',
         expect.arrayContaining([
           expect.objectContaining({
-            squadId: 'ext-squad',
-            squadName: 'External Squad',
-            squadIcon: '🔌',
+            agentId: 'ext-squad',
+            agentName: 'External Squad',
+            agentIcon: '🔌',
           }),
         ]),
       );

--- a/src/__tests__/tree-providers-extra.test.ts
+++ b/src/__tests__/tree-providers-extra.test.ts
@@ -53,7 +53,7 @@ describe('EditlessTreeProvider — Extra Visibility Tests', () => {
   });
 
   it('renders hidden agents with dimmed icon and (hidden) description inside group', () => {
-    const hiddenId = 'squad-hidden';
+    const hiddenId = 'agent-hidden';
     mockAgentSettings.isHidden.mockImplementation((id: string) => id === hiddenId);
     
     provider.setDiscoveredItems([
@@ -69,7 +69,7 @@ describe('EditlessTreeProvider — Extra Visibility Tests', () => {
     const hiddenItem = hiddenChildren.find(r => r.squadId === hiddenId);
 
     expect(hiddenItem).toBeDefined();
-    expect(hiddenItem!.contextValue).toBe('squad-hidden');
+    expect(hiddenItem!.contextValue).toBe('agent-hidden');
     expect(hiddenItem!.description).toContain('(hidden)');
     
     // Check icon is dimmed

--- a/src/__tests__/tree-providers.test.ts
+++ b/src/__tests__/tree-providers.test.ts
@@ -497,7 +497,7 @@ describe('EditlessTreeProvider — findTerminalItem', () => {
     const agentSettings = createMockAgentSettings(squads);
     const mockTerminalMgr = {
       getTerminalInfo: vi.fn().mockReturnValue(undefined),
-      getTerminalsForSquad: vi.fn().mockReturnValue([]),
+      getTerminalsForAgent: vi.fn().mockReturnValue([]),
       getOrphanedSessions: vi.fn().mockReturnValue([]),
       getSessionState: vi.fn().mockReturnValue('inactive'),
       onDidChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
@@ -517,8 +517,8 @@ describe('EditlessTreeProvider — findTerminalItem', () => {
     const mockTerminal = { name: 'test-session' } as never;
 
     const mockTerminalMgr = {
-      getTerminalInfo: vi.fn().mockReturnValue({ squadId: 'squad-a', displayName: 'Test', labelKey: 'lk', createdAt: new Date() }),
-      getTerminalsForSquad: vi.fn().mockReturnValue([{ terminal: mockTerminal, info: { squadId: 'squad-a', displayName: 'Test', labelKey: 'lk', createdAt: new Date() } }]),
+      getTerminalInfo: vi.fn().mockReturnValue({ agentId: 'squad-a', displayName: 'Test', labelKey: 'lk', createdAt: new Date() }),
+      getTerminalsForAgent: vi.fn().mockReturnValue([{ terminal: mockTerminal, info: { agentId: 'squad-a', displayName: 'Test', labelKey: 'lk', createdAt: new Date() } }]),
       getOrphanedSessions: vi.fn().mockReturnValue([]),
       getSessionState: vi.fn().mockReturnValue('inactive'),
       onDidChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
@@ -678,7 +678,7 @@ describe('EditlessTreeProvider — visibility filtering', () => {
     const hiddenChildren = provider.getChildren(hiddenGroup!);
     expect(hiddenChildren).toHaveLength(1);
     expect(hiddenChildren[0].squadId).toBe('squad-a');
-    expect(hiddenChildren[0].contextValue).toBe('squad-hidden');
+    expect(hiddenChildren[0].contextValue).toBe('agent-hidden');
   });
 
   it('"Hidden" group shown when everything hidden', () => {
@@ -867,7 +867,7 @@ describe('EditlessTreeProvider — discovered agents', () => {
     const hiddenChildren = provider.getChildren(hiddenGroup!);
     expect(hiddenChildren).toHaveLength(1);
     expect(hiddenChildren[0].label).toBe('🤖 Bot One');
-    expect(hiddenChildren[0].contextValue).toBe('squad-hidden');
+    expect(hiddenChildren[0].contextValue).toBe('agent-hidden');
   });
 });
 
@@ -954,7 +954,7 @@ describe('EditlessTreeProvider — squad item description', () => {
     const squads = [{ id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' }];
     const agentSettings = createMockAgentSettings(squads);
     const mockTerminalMgr = {
-      getTerminalsForSquad: vi.fn().mockReturnValue([
+      getTerminalsForAgent: vi.fn().mockReturnValue([
         { terminal: {}, info: {} },
         { terminal: {}, info: {} },
       ]),
@@ -976,7 +976,7 @@ describe('EditlessTreeProvider — squad item description', () => {
     const squads = [{ id: 'squad-a', name: 'Squad A', path: '/a', icon: '🤖', universe: 'test' }];
     const agentSettings = createMockAgentSettings(squads);
     const mockTerminalMgr = {
-      getTerminalsForSquad: vi.fn().mockReturnValue([{ terminal: {}, info: {} }]),
+      getTerminalsForAgent: vi.fn().mockReturnValue([{ terminal: {}, info: {} }]),
       getOrphanedSessions: vi.fn().mockReturnValue([]),
       getSessionState: vi.fn().mockReturnValue('inactive'),
       onDidChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
@@ -1142,7 +1142,7 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
 
   function makeTerminalManager(orphans: Array<Record<string, unknown>>) {
     return {
-      getTerminalsForSquad: () => [],
+      getTerminalsForAgent: () => [],
       getOrphanedSessions: () => orphans,
       onDidChange: (cb: Function) => ({ dispose: () => {} }),
       getSessionState: () => 'orphaned',
@@ -1160,9 +1160,9 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
       id: 'orphan-1',
       labelKey: 'terminal:orphan-1',
       displayName: '🤖 Squad A #1',
-      squadId: 'squad-a',
-      squadName: 'Squad A',
-      squadIcon: '🤖',
+      agentId: 'squad-a',
+      agentName: 'Squad A',
+      agentIcon: '🤖',
       index: 1,
       createdAt: '2026-01-01T00:00:00.000Z',
       terminalName: '🤖 Squad A #1',
@@ -1191,9 +1191,9 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
       id: 'orphan-2',
       labelKey: 'terminal:orphan-2',
       displayName: '🤖 Squad A #1',
-      squadId: 'squad-a',
-      squadName: 'Squad A',
-      squadIcon: '🤖',
+      agentId: 'squad-a',
+      agentName: 'Squad A',
+      agentIcon: '🤖',
       index: 1,
       createdAt: '2026-01-01T00:00:00.000Z',
       terminalName: '🤖 Squad A #1',
@@ -1219,13 +1219,13 @@ describe('EditlessTreeProvider — orphan item resumability', () => {
 
   it('should have different tooltip for resumable vs non-resumable', () => {
     const resumableOrphan = {
-      id: 'res-1', labelKey: 'terminal:res-1', displayName: 'Test', squadId: 'squad-a',
-      squadName: 'Squad A', squadIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z',
+      id: 'res-1', labelKey: 'terminal:res-1', displayName: 'Test', agentId: 'squad-a',
+      agentName: 'Squad A', agentIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z',
       terminalName: 'Test', lastSeenAt: Date.now(), rebootCount: 0, agentSessionId: 'sess-1',
     };
     const nonResumableOrphan = {
-      id: 'non-1', labelKey: 'terminal:non-1', displayName: 'Test2', squadId: 'squad-a',
-      squadName: 'Squad A', squadIcon: '🤖', index: 2, createdAt: '2026-01-01T00:00:00.000Z',
+      id: 'non-1', labelKey: 'terminal:non-1', displayName: 'Test2', agentId: 'squad-a',
+      agentName: 'Squad A', agentIcon: '🤖', index: 2, createdAt: '2026-01-01T00:00:00.000Z',
       terminalName: 'Test2', lastSeenAt: Date.now(), rebootCount: 0,
     };
 
@@ -1287,7 +1287,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
     orphans: Array<Record<string, unknown>>,
   ) {
     return {
-      getTerminalsForSquad: vi.fn().mockReturnValue(terminals),
+      getTerminalsForAgent: vi.fn().mockReturnValue(terminals),
       getOrphanedSessions: vi.fn().mockReturnValue(orphans),
       onDidChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
       getSessionState: vi.fn().mockReturnValue('orphaned'),
@@ -1299,8 +1299,8 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
 
   it('squad item shows resumable count in description when orphans exist', () => {
     const orphans = [
-      { id: 'o1', squadId: 'squad-a', agentSessionId: 'sess-1', displayName: 'Test', labelKey: 'k', squadName: 'A', squadIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T', lastSeenAt: Date.now(), rebootCount: 0 },
-      { id: 'o2', squadId: 'squad-a', agentSessionId: 'sess-2', displayName: 'Test2', labelKey: 'k2', squadName: 'A', squadIcon: '🤖', index: 2, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T2', lastSeenAt: Date.now(), rebootCount: 0 },
+      { id: 'o1', agentId: 'squad-a', agentSessionId: 'sess-1', displayName: 'Test', labelKey: 'k', agentName: 'A', agentIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T', lastSeenAt: Date.now(), rebootCount: 0 },
+      { id: 'o2', agentId: 'squad-a', agentSessionId: 'sess-2', displayName: 'Test2', labelKey: 'k2', agentName: 'A', agentIcon: '🤖', index: 2, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T2', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
     const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings(standaloneSquad) as never), createMockAgentSettings(standaloneSquad) as never, tm as never);
@@ -1313,7 +1313,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
 
   it('standalone squad with 0 terminals but orphans still shows as Collapsed', () => {
     const orphans = [
-      { id: 'o1', squadId: 'squad-a', agentSessionId: 'sess-1', displayName: 'Test', labelKey: 'k', squadName: 'A', squadIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T', lastSeenAt: Date.now(), rebootCount: 0 },
+      { id: 'o1', agentId: 'squad-a', agentSessionId: 'sess-1', displayName: 'Test', labelKey: 'k', agentName: 'A', agentIcon: '🤖', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'T', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
     const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings(standaloneSquad) as never), createMockAgentSettings(standaloneSquad) as never, tm as never);
@@ -1327,7 +1327,7 @@ describe('EditlessTreeProvider — resumable session count at tree level', () =>
 
   it('default agent item shows resumable count in description', () => {
     const orphans = [
-      { id: 'o1', squadId: 'builtin:copilot-cli', agentSessionId: 'sess-1', displayName: 'CLI', labelKey: 'k', squadName: 'CLI', squadIcon: '', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'CLI', lastSeenAt: Date.now(), rebootCount: 0 },
+      { id: 'o1', agentId: 'builtin:copilot-cli', agentSessionId: 'sess-1', displayName: 'CLI', labelKey: 'k', agentName: 'CLI', agentIcon: '', index: 1, createdAt: '2026-01-01T00:00:00.000Z', terminalName: 'CLI', lastSeenAt: Date.now(), rebootCount: 0 },
     ];
     const tm = makeTerminalManager([], orphans);
     const provider = new EditlessTreeProvider(new AgentStateManager(createMockAgentSettings([]) as never), createMockAgentSettings([]) as never, tm as never);

--- a/src/commands/agent-commands.ts
+++ b/src/commands/agent-commands.ts
@@ -183,7 +183,7 @@ export function register(context: vscode.ExtensionContext, deps: AgentCommandDep
       const rawId = item.squadId ?? item.id;
       if (!rawId) return;
       const id = rawId.replace(/^discovered:/, '');
-      if (item.type === 'squad-hidden') {
+      if (item.type === 'agent-hidden') {
         agentSettings.show(id);
       } else {
         agentSettings.hide(id);
@@ -192,7 +192,7 @@ export function register(context: vscode.ExtensionContext, deps: AgentCommandDep
     }),
   );
 
-  // Show a single hidden agent (context menu on squad-hidden items)
+  // Show a single hidden agent (context menu on agent-hidden items)
   context.subscriptions.push(
     vscode.commands.registerCommand('editless.showAgent', (item?: EditlessTreeItem) => {
       if (!item) return;

--- a/src/commands/session-commands.ts
+++ b/src/commands/session-commands.ts
@@ -90,7 +90,7 @@ export function register(context: vscode.ExtensionContext, deps: SessionCommandD
         });
         if (value !== undefined && value.length > 0) {
           const info = terminalManager.getTerminalInfo(terminal);
-          const iconPrefix = info?.squadIcon ? `${info.squadIcon} ` : '';
+          const iconPrefix = info?.agentIcon ? `${info.agentIcon} ` : '';
           await renameTerminalTab(terminal, `${iconPrefix}${value}`);
           labelManager.setLabel(labelKey, value);
           terminalManager.renameSession(terminal, value);
@@ -124,7 +124,7 @@ export function register(context: vscode.ExtensionContext, deps: SessionCommandD
         });
         if (value !== undefined && value.length > 0) {
           const info = terminalManager.getTerminalInfo(pick.terminal);
-          const iconPrefix = info?.squadIcon ? `${info.squadIcon} ` : '';
+          const iconPrefix = info?.agentIcon ? `${info.agentIcon} ` : '';
           await renameTerminalTab(pick.terminal, `${iconPrefix}${value}`);
           labelManager.setLabel(pick.labelKey, value);
           terminalManager.renameSession(pick.terminal, value);
@@ -268,12 +268,12 @@ export function register(context: vscode.ExtensionContext, deps: SessionCommandD
       const orphanEntry = orphanedSessions.find(e => e.agentSessionId === sessionId);
       if (orphanEntry) {
         terminalManager.registerExternalTerminal(terminal, {
-          squadId: orphanEntry.squadId,
-          squadName: orphanEntry.squadName,
-          squadIcon: orphanEntry.squadIcon,
+          agentId: orphanEntry.agentId,
+          agentName: orphanEntry.agentName,
+          agentIcon: orphanEntry.agentIcon,
           agentSessionId: sessionId,
           launchCommand: orphanEntry.launchCommand,
-          squadPath: orphanEntry.squadPath,
+          agentPath: orphanEntry.agentPath,
         });
       }
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -5,7 +5,7 @@ import { resolveTeamMd, TEAM_DIR_NAMES } from './team-dir';
 
 const TEAM_ROSTER_PREFIX = /^team\s+roster\s*[—\-:]\s*(.+)$/i;
 
-export function normalizeSquadName(name: string, fallback: string): string {
+export function normalizeAgentName(name: string, fallback: string): string {
   const trimmed = name.trim();
   if (!trimmed) {
     return fallback;
@@ -30,7 +30,7 @@ export function parseTeamMd(content: string, folderName: string): Pick<AgentTeam
 
   const headingMatch = content.match(/^#\s+(.+)$/m);
   if (headingMatch) {
-    name = normalizeSquadName(headingMatch[1], folderName);
+    name = normalizeAgentName(headingMatch[1], folderName);
   }
 
   const blockquoteMatch = content.match(/^>\s+(.+)$/m);

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -6,8 +6,8 @@ import type { TerminalManager, PersistedTerminalInfo, SessionState } from './ter
 import type { SessionLabelManager } from './session-labels';
 import type { SessionContextResolver } from './session-context';
 import type { AgentTeamConfig, SquadState, AgentInfo, SessionContext } from './types';
-import type { DiscoveredItem } from './unified-discovery';
-import { normalizeSquadName } from './discovery';
+import { type DiscoveredItem, toAgentTeamConfig } from './unified-discovery';
+import { normalizeAgentName } from './discovery';
 import type { AgentSettingsManager } from './agent-settings';
 import type { AgentStateManager } from './agent-state-manager';
 
@@ -15,7 +15,7 @@ import type { AgentStateManager } from './agent-state-manager';
 // Tree item types
 // ---------------------------------------------------------------------------
 
-export type TreeItemType = 'squad' | 'squad-hidden' | 'category' | 'agent' | 'terminal' | 'orphanedSession' | 'default-agent';
+export type TreeItemType = 'squad' | 'agent-hidden' | 'category' | 'agent' | 'terminal' | 'orphanedSession' | 'default-agent';
 
 /** Sentinel ID for the built-in Copilot CLI entry. */
 export const DEFAULT_COPILOT_CLI_ID = 'builtin:copilot-cli';
@@ -118,7 +118,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     // Build the parent squad item so getParent() can traverse back to root
     const rootItems = this.getRootItems();
     let parentItem: EditlessTreeItem | undefined = rootItems.find(item =>
-      (item.type === 'squad' || item.type === 'default-agent') && item.squadId === info.squadId,
+      (item.type === 'squad' || item.type === 'default-agent') && item.squadId === info.agentId,
     );
 
     // Also search inside the hidden group
@@ -126,7 +126,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
       const hiddenGroup = rootItems.find(item => item.type === 'category' && item.categoryKind === 'hidden');
       if (hiddenGroup) {
         parentItem = this.getHiddenGroupChildren(hiddenGroup)
-          .find(item => item.squadId === info.squadId);
+          .find(item => item.squadId === info.agentId);
       }
     }
     if (!parentItem) return undefined;
@@ -136,8 +136,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         .find(item => item.type === 'terminal' && item.terminal === terminal);
     }
 
-    const squadChildren = this.getSquadChildren(info.squadId, parentItem);
-    return squadChildren.find(item => item.type === 'terminal' && item.terminal === terminal);
+    const agentChildren = this.getAgentChildren(info.agentId, parentItem);
+    return agentChildren.find(item => item.type === 'terminal' && item.terminal === terminal);
   }
 
   // -- TreeDataProvider implementation -------------------------------------
@@ -157,8 +157,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     if (element.type === 'default-agent' && element.squadId) {
       return this.getDefaultAgentChildren(element);
     }
-    if ((element.type === 'squad' || element.type === 'squad-hidden') && element.squadId) {
-      return this.getSquadChildren(element.squadId, element);
+    if ((element.type === 'squad' || element.type === 'agent-hidden') && element.squadId) {
+      return this.getAgentChildren(element.squadId, element);
     }
     if (element.type === 'category' && element.categoryKind === 'hidden') {
       return this.getHiddenGroupChildren(element);
@@ -207,19 +207,19 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     // For squads with a path, build a full squad item from discovery + settings
     if (isSquad) {
       const settings = this.agentSettings.get(disc.id);
-      const displayName = normalizeSquadName(settings?.name || disc.name, disc.id);
+      const displayName = normalizeAgentName(settings?.name || disc.name, disc.id);
       const icon = settings?.icon || (isStandalone ? '🤖' : '🔷');
 
       const terminalCount = this.terminalManager
-        ? this.terminalManager.getTerminalsForSquad(disc.id).length
+        ? this.terminalManager.getTerminalsForAgent(disc.id).length
         : 0;
       const orphanCount = this.terminalManager
         ? this.terminalManager.getOrphanedSessions()
-            .filter(o => o.squadId === disc.id && !!o.agentSessionId)
+            .filter(o => o.agentId === disc.id && !!o.agentSessionId)
             .length
         : 0;
 
-      const itemType: TreeItemType = isHidden ? 'squad-hidden' : 'squad';
+      const itemType: TreeItemType = isHidden ? 'agent-hidden' : 'squad';
 
       const item = new EditlessTreeItem(
         `${icon} ${displayName}`,
@@ -266,14 +266,14 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     const settings = this.agentSettings.get(disc.id);
     const displayName = settings?.name || disc.name;
     const icon = settings?.icon || '🤖';
-    const itemType: TreeItemType = isHidden ? 'squad-hidden' : 'squad';
+    const itemType: TreeItemType = isHidden ? 'agent-hidden' : 'squad';
 
     const terminalCount = this.terminalManager
-      ? this.terminalManager.getTerminalsForSquad(disc.id).length
+      ? this.terminalManager.getTerminalsForAgent(disc.id).length
       : 0;
     const orphanCount = this.terminalManager
       ? this.terminalManager.getOrphanedSessions()
-          .filter(o => o.squadId === disc.id && !!o.agentSessionId)
+          .filter(o => o.agentId === disc.id && !!o.agentSessionId)
           .length
       : 0;
 
@@ -310,12 +310,12 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
 
   private buildDefaultAgentItem(): EditlessTreeItem {
     const terminalCount = this.terminalManager
-      ? this.terminalManager.getTerminalsForSquad(DEFAULT_COPILOT_CLI_ID).length
+      ? this.terminalManager.getTerminalsForAgent(DEFAULT_COPILOT_CLI_ID).length
       : 0;
 
     const orphanCount = this.terminalManager
       ? this.terminalManager.getOrphanedSessions()
-          .filter(o => o.squadId === DEFAULT_COPILOT_CLI_ID && !!o.agentSessionId)
+          .filter(o => o.agentId === DEFAULT_COPILOT_CLI_ID && !!o.agentSessionId)
           .length
       : 0;
 
@@ -349,7 +349,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     if (!this.terminalManager) return [];
 
     const children: EditlessTreeItem[] = [];
-    for (const { terminal, info } of this.terminalManager.getTerminalsForSquad(DEFAULT_COPILOT_CLI_ID)) {
+    for (const { terminal, info } of this.terminalManager.getTerminalsForAgent(DEFAULT_COPILOT_CLI_ID)) {
       const sessionState = this.terminalManager.getSessionState(terminal) ?? 'inactive';
 
       const elapsed = Date.now() - info.createdAt.getTime();
@@ -390,7 +390,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     return this.stateManager.getState(squadId);
   }
 
-  private getSquadChildren(squadId: string, parentItem?: EditlessTreeItem): EditlessTreeItem[] {
+  private getAgentChildren(squadId: string, parentItem?: EditlessTreeItem): EditlessTreeItem[] {
     const state = this.getState(squadId);
     if (!state) return [];
 
@@ -401,7 +401,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         ? this.sessionContextResolver.resolveForSquad(state.config.path)
         : null;
 
-      for (const { terminal, info } of this.terminalManager.getTerminalsForSquad(squadId)) {
+      for (const { terminal, info } of this.terminalManager.getTerminalsForAgent(squadId)) {
         const sessionState = this.terminalManager.getSessionState(terminal) ?? 'inactive';
         const lastActivityAt = this.terminalManager.getLastActivityAt(terminal);
 
@@ -427,13 +427,13 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
         children.push(item);
       }
 
-      for (const orphan of this.terminalManager.getOrphanedSessions().filter(o => o.squadId === squadId)) {
+      for (const orphan of this.terminalManager.getOrphanedSessions().filter(o => o.agentId === squadId)) {
         children.push(this._buildOrphanItem(orphan));
       }
 
       // Hint when squad has no sessions yet
-      const hasTerminals = this.terminalManager.getTerminalsForSquad(squadId).length > 0;
-      const hasOrphans = this.terminalManager.getOrphanedSessions().some(o => o.squadId === squadId);
+      const hasTerminals = this.terminalManager.getTerminalsForAgent(squadId).length > 0;
+      const hasOrphans = this.terminalManager.getOrphanedSessions().some(o => o.agentId === squadId);
       if (!hasTerminals && !hasOrphans) {
         const hint = new EditlessTreeItem('No active sessions', 'category');
         hint.description = 'Click + to launch';
@@ -529,8 +529,8 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     item.contextValue = 'orphanedSession';
     item.tooltip = new vscode.MarkdownString(
       resumable
-        ? [`**${entry.displayName}**`, `Squad: ${entry.squadName}`, 'Your conversation is saved. Click to pick up where you left off.'].join('\n\n')
-        : [`**${entry.displayName}**`, `Squad: ${entry.squadName}`, 'This terminal was closed. The conversation cannot be resumed.'].join('\n\n'),
+        ? [`**${entry.displayName}**`, `Agent: ${entry.agentName}`, 'Your conversation is saved. Click to pick up where you left off.'].join('\n\n')
+        : [`**${entry.displayName}**`, `Agent: ${entry.agentName}`, 'This terminal was closed. The conversation cannot be resumed.'].join('\n\n'),
     );
     item.command = {
       command: 'editless.relaunchSession',

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -21,14 +21,14 @@ export interface TerminalInfo {
   labelKey: string;
   displayName: string;
   originalName: string;
-  squadId: string;
-  squadName: string;
-  squadIcon: string;
+  agentId: string;
+  agentName: string;
+  agentIcon: string;
   index: number;
   createdAt: Date;
   agentSessionId?: string;
   launchCommand?: string;
-  squadPath?: string;
+  agentPath?: string;
   configDir?: string;
 }
 
@@ -37,9 +37,9 @@ export interface PersistedTerminalInfo {
   labelKey: string;
   displayName: string;
   originalName?: string;
-  squadId: string;
-  squadName: string;
-  squadIcon: string;
+  agentId: string;
+  agentName: string;
+  agentIcon: string;
   index: number;
   createdAt: string;
   terminalName: string;
@@ -48,11 +48,11 @@ export interface PersistedTerminalInfo {
   rebootCount: number;
   agentSessionId?: string;
   launchCommand?: string;
-  squadPath?: string;
+  agentPath?: string;
   configDir?: string;
 }
 
-const STORAGE_KEY = 'editless.terminalSessions';
+const STORAGE_KEY= 'editless.terminalSessions';
 
 /** Strip Unicode emoji (and variation selectors / ZWJ sequences) from a string. */
 export function stripEmoji(str: string): string {
@@ -248,14 +248,14 @@ export class TerminalManager implements vscode.Disposable {
       labelKey,
       displayName,
       originalName: displayName,
-      squadId: config.id,
-      squadName: config.name,
-      squadIcon: config.icon,
+      agentId: config.id,
+      agentName: config.name,
+      agentIcon: config.icon,
       index,
       createdAt: new Date(),
       agentSessionId: uuid,
       launchCommand: baseCmd,
-      squadPath: config.path,
+      agentPath: config.path,
       configDir,
     };
 
@@ -296,16 +296,16 @@ export class TerminalManager implements vscode.Disposable {
   registerExternalTerminal(
     terminal: vscode.Terminal,
     metadata: {
-      squadId: string;
-      squadName: string;
-      squadIcon: string;
+      agentId: string;
+      agentName: string;
+      agentIcon: string;
       agentSessionId?: string;
       launchCommand?: string;
-      squadPath?: string;
+      agentPath?: string;
     },
   ): void {
-    const index = this._counters.get(metadata.squadId) || 1;
-    const id = `${metadata.squadId}-${Date.now()}-${index}`;
+    const index = this._counters.get(metadata.agentId) || 1;
+    const id = `${metadata.agentId}-${Date.now()}-${index}`;
     const labelKey = `terminal:${id}`;
 
     const info: TerminalInfo = {
@@ -313,14 +313,14 @@ export class TerminalManager implements vscode.Disposable {
       labelKey,
       displayName: terminal.name,
       originalName: terminal.name,
-      squadId: metadata.squadId,
-      squadName: metadata.squadName,
-      squadIcon: metadata.squadIcon,
+      agentId: metadata.agentId,
+      agentName: metadata.agentName,
+      agentIcon: metadata.agentIcon,
       index,
       createdAt: new Date(),
       agentSessionId: metadata.agentSessionId,
       launchCommand: metadata.launchCommand,
-      squadPath: metadata.squadPath,
+      agentPath: metadata.agentPath,
     };
 
     this._terminals.set(terminal, info);
@@ -336,15 +336,15 @@ export class TerminalManager implements vscode.Disposable {
       this._sessionWatchers.set(terminal, watcher);
     }
 
-    this._counters.set(metadata.squadId, index + 1);
+    this._counters.set(metadata.agentId, index + 1);
     this._persist();
     this._scheduleChange();
   }
 
-  getTerminalsForSquad(squadId: string): { terminal: vscode.Terminal; info: TerminalInfo }[] {
+  getTerminalsForAgent(agentId: string): { terminal: vscode.Terminal; info: TerminalInfo }[] {
     const results: { terminal: vscode.Terminal; info: TerminalInfo }[] = [];
     for (const [terminal, info] of this._terminals) {
-      if (info.squadId === squadId) {
+      if (info.agentId === agentId) {
         results.push({ terminal, info });
       }
     }
@@ -438,14 +438,14 @@ export class TerminalManager implements vscode.Disposable {
       labelKey: entry.labelKey,
       displayName: entry.displayName,
       originalName: orig,
-      squadId: entry.squadId,
-      squadName: entry.squadName,
-      squadIcon: entry.squadIcon,
+      agentId: entry.agentId,
+      agentName: entry.agentName,
+      agentIcon: entry.agentIcon,
       index: entry.index,
       createdAt: new Date(entry.createdAt),
       agentSessionId: entry.agentSessionId,
       launchCommand: entry.launchCommand,
-      squadPath: entry.squadPath,
+      agentPath: entry.agentPath,
       configDir: entry.configDir,
     });
 
@@ -509,15 +509,15 @@ export class TerminalManager implements vscode.Disposable {
 
     const terminal = vscode.window.createTerminal({
       name: entry.displayName,
-      cwd: resolveTerminalCwd(entry.squadPath),
+      cwd: resolveTerminalCwd(entry.agentPath),
       isTransient: true,
       iconPath: new vscode.ThemeIcon('terminal'),
       env: {
         ...env,
         COPILOT_CUSTOM_INSTRUCTIONS_DIRS: [process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS, EDITLESS_INSTRUCTIONS_DIR].filter(Boolean).join(path.delimiter),
         EDITLESS_TERMINAL_ID: entry.id,
-        EDITLESS_SQUAD_ID: entry.squadId,
-        EDITLESS_SQUAD_NAME: entry.squadName,
+        EDITLESS_SQUAD_ID: entry.agentId,
+        EDITLESS_SQUAD_NAME: entry.agentName,
       },
     });
 
@@ -539,14 +539,14 @@ export class TerminalManager implements vscode.Disposable {
       labelKey: entry.labelKey,
       displayName: entry.displayName,
       originalName: entry.originalName ?? entry.displayName,
-      squadId: entry.squadId,
-      squadName: entry.squadName,
-      squadIcon: entry.squadIcon,
+      agentId: entry.agentId,
+      agentName: entry.agentName,
+      agentIcon: entry.agentIcon,
       index: entry.index,
       createdAt: new Date(),
       agentSessionId: entry.agentSessionId,
       launchCommand: entry.launchCommand,
-      squadPath: entry.squadPath,
+      agentPath: entry.agentPath,
       configDir: entry.configDir,
     });
     this._setLaunching(terminal);
@@ -613,25 +613,25 @@ export class TerminalManager implements vscode.Disposable {
 
   /**
    * For terminals missing an agentSessionId, try to detect the Copilot session
-   * by matching session-state directories whose cwd matches the terminal's squadPath.
+   * by matching session-state directories whose cwd matches the terminal's agentPath.
    */
   detectSessionIds(): void {
     if (!this._sessionResolver) return;
 
-    const squadPaths: string[] = [];
+    const agentPaths: string[] = [];
     for (const info of this._terminals.values()) {
-      if (!info.agentSessionId && info.squadPath) {
-        squadPaths.push(info.squadPath);
+      if (!info.agentSessionId && info.agentPath) {
+        agentPaths.push(info.agentPath);
       }
     }
-    if (squadPaths.length === 0) return;
+    if (agentPaths.length === 0) return;
 
-    const sessions = this._sessionResolver.resolveAll(squadPaths);
+    const sessions = this._sessionResolver.resolveAll(agentPaths);
     let changed = false;
 
     for (const [terminal, info] of this._terminals) {
-      if (info.agentSessionId || !info.squadPath) continue;
-      const ctx = sessions.get(info.squadPath);
+      if (info.agentSessionId || !info.agentPath) continue;
+      const ctx = sessions.get(info.agentPath);
       if (!ctx) continue;
 
       // Only claim sessions created after the terminal was launched
@@ -770,14 +770,14 @@ export class TerminalManager implements vscode.Disposable {
         labelKey: persisted.labelKey,
         displayName: persisted.displayName,
         originalName: persisted.originalName ?? persisted.displayName,
-        squadId: persisted.squadId,
-        squadName: persisted.squadName,
-        squadIcon: persisted.squadIcon,
+        agentId: persisted.agentId,
+        agentName: persisted.agentName,
+        agentIcon: persisted.agentIcon,
         index: persisted.index,
         createdAt: new Date(persisted.createdAt),
         agentSessionId: persisted.agentSessionId,
         launchCommand: persisted.launchCommand,
-        squadPath: persisted.squadPath,
+        agentPath: persisted.agentPath,
         configDir: persisted.configDir,
       });
       this._lastActivityAt.set(match, persisted.lastActivityAt ?? persisted.lastSeenAt);
@@ -797,11 +797,11 @@ export class TerminalManager implements vscode.Disposable {
     };
 
     // Multi-signal matching: each stage only considers unclaimed terminals
-    // Pass 1: Index-based — match by squadId + terminal index
+    // Pass 1: Index-based — match by agentId + terminal index
     runPass((t, p) => {
       for (const [, info] of this._terminals) {
-        if (info.squadId === p.squadId && info.index === p.index - 1) return true;
-        if (info.squadId === p.squadId && info.index === p.index + 1) return true;
+        if (info.agentId === p.agentId && info.index === p.index - 1) return true;
+        if (info.agentId === p.agentId && info.index === p.index + 1) return true;
       }
       return false;
     });
@@ -830,9 +830,9 @@ export class TerminalManager implements vscode.Disposable {
     }
 
     for (const info of this._terminals.values()) {
-      const current = this._counters.get(info.squadId) || 0;
+      const current = this._counters.get(info.agentId) || 0;
       if (info.index >= current) {
-        this._counters.set(info.squadId, info.index + 1);
+        this._counters.set(info.agentId, info.index + 1);
       }
     }
 
@@ -858,7 +858,7 @@ export class TerminalManager implements vscode.Disposable {
         rebootCount: 0,
         agentSessionId: info.agentSessionId,
         launchCommand: info.launchCommand,
-        squadPath: info.squadPath,
+        agentPath: info.agentPath,
       });
     }
     // Preserve unmatched saved entries so they aren't lost during timing races

--- a/src/unified-discovery.ts
+++ b/src/unified-discovery.ts
@@ -108,7 +108,7 @@ export function discoverAll(
     for (const squad of discovered) {
       if (seenIds.has(squad.id)) { continue; }
       seenIds.add(squad.id);
-      items.push(squadConfigToItem(squad));
+      items.push(agentConfigToItem(squad));
     }
   }
 
@@ -135,7 +135,7 @@ export function discoverAll(
   });
 }
 
-function squadConfigToItem(cfg: AgentTeamConfig): DiscoveredItem {
+function agentConfigToItem(cfg: AgentTeamConfig): DiscoveredItem {
   return {
     id: cfg.id,
     name: cfg.name,


### PR DESCRIPTION
## Summary

Closes #429

### Problem
Functions and types that apply to both agents and squads used `squad` terminology. ~875 references across ~38 files — many are genuinely squad-specific, but generic ones should say `agent`.

### Renames

**Functions:**
- `normalizeSquadName()` → `normalizeAgentName()` (discovery.ts)
- `getTerminalsForSquad()` → `getTerminalsForAgent()` (terminal-manager.ts)
- `getSquadChildren()` → `getAgentChildren()` (editless-tree.ts)
- `squadConfigToItem()` → `agentConfigToItem()` (unified-discovery.ts)

**Fields in TerminalInfo/PersistedTerminalInfo:**
- `squadId` → `agentId`, `squadName` → `agentName`, `squadIcon` → `agentIcon`, `squadPath` → `agentPath`

**Context values:**
- `squad-hidden` → `agent-hidden` (package.json when clauses + tree items)

### Kept as squad (genuinely squad-specific)
- `SquadState`, `SquadWatcher`, `.squad/` paths, `scanSquad()`, `squad-ui-integration`  
- Squad-specific commands: `editless.discoverSquads`, `editless.renameSquad`, `editless.openInSquadUi`
- Environment variables: `EDITLESS_SQUAD_ID`, `EDITLESS_SQUAD_NAME`
- `EditlessTreeItem.squadId` — identifies both agents and squads in tree (kept for backward compat)

### Impact
- 13 files modified, 0 files renamed
- 962 tests passing (zero regressions)