### PR TITLE
feat: auto-discover git worktrees for agents and squads

### DIFF
--- a/package.json
+++ b/package.json
@@ -886,6 +886,14 @@
           "description": "Auto-refresh interval in minutes for Work Items and PRs panels. Set to 0 to disable.",
           "markdownDescription": "Auto-refresh interval in minutes for the **Work Items** and **Pull Requests** panels.\n\nEditLess also refreshes when the VS Code window regains focus.\n\nSet to `0` to disable auto-refresh entirely (manual refresh only).\n\nDefault: `5` minutes.",
           "scope": "window",
+          "order": 34
+        },
+        "editless.discovery.worktreesOutsideWorkspace": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include git worktrees located outside the current workspace folders in discovery results.",
+          "markdownDescription": "When enabled, EditLess will include git worktrees that live outside the current VS Code workspace folders.\n\nDefault: `false` (only worktrees inside workspace folders are shown).",
+          "scope": "window",
           "order": 35
         }
       }

--- a/src/__tests__/agent-settings.test.ts
+++ b/src/__tests__/agent-settings.test.ts
@@ -493,3 +493,55 @@ describe('AgentSettingsManager — pickNextIcon', () => {
     expect(mgr.pickNextIcon()).toBe('🟠');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Worktree settings inheritance via :wt: convention (#442)
+// ---------------------------------------------------------------------------
+
+describe('AgentSettingsManager — worktree inheritance', () => {
+  it('get() merges parent settings for :wt: id', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    mgr.update('my-squad', { model: 'gpt-5', icon: '🔷' });
+
+    const settings = mgr.get('my-squad:wt:feat-auth');
+    expect(settings?.model).toBe('gpt-5');
+    expect(settings?.icon).toBe('🔷');
+  });
+
+  it('get() allows worktree-specific overrides to win', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    mgr.update('my-squad', { model: 'gpt-5', icon: '🔷' });
+    mgr.update('my-squad:wt:feat-auth', { model: 'o4-mini' });
+
+    const settings = mgr.get('my-squad:wt:feat-auth');
+    expect(settings?.model).toBe('o4-mini'); // overridden
+    expect(settings?.icon).toBe('🔷');       // inherited
+  });
+
+  it('get() returns undefined when neither parent nor worktree settings exist', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    expect(mgr.get('unknown:wt:branch')).toBeUndefined();
+  });
+
+  it('isHidden() cascades from parent to worktree child', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    mgr.hide('my-squad');
+
+    expect(mgr.isHidden('my-squad:wt:feat-auth')).toBe(true);
+  });
+
+  it('isHidden() returns false for worktree when parent is not hidden', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    mgr.update('my-squad', { name: 'Visible Squad' });
+
+    expect(mgr.isHidden('my-squad:wt:feat-auth')).toBe(false);
+  });
+
+  it('isHidden() returns true when worktree itself is hidden', () => {
+    const mgr = new AgentSettingsManager(settingsPath);
+    mgr.update('my-squad', { name: 'Visible' });
+    mgr.hide('my-squad:wt:feat-auth');
+
+    expect(mgr.isHidden('my-squad:wt:feat-auth')).toBe(true);
+  });
+});

--- a/src/__tests__/extension-commands-extra.test.ts
+++ b/src/__tests__/extension-commands-extra.test.ts
@@ -100,7 +100,7 @@ vi.mock('../agent-state-manager', () => ({
     getState = vi.fn(); invalidate = vi.fn(); invalidateAll = vi.fn(); setDiscoveredItems = vi.fn(); getDiscoveredItems = vi.fn().mockReturnValue([]); onDidChange = vi.fn(() => ({ dispose: vi.fn() })); dispose = vi.fn();
   },
 }));
-vi.mock('../unified-discovery', () => ({ discoverAll: vi.fn(() => []) }));
+vi.mock('../unified-discovery', () => ({ discoverAll: vi.fn(() => []), enrichWithWorktrees: vi.fn((items: unknown[]) => items) }));
 vi.mock('../watcher', () => ({ SquadWatcher: class {} }));
 vi.mock('../status-bar', () => ({ EditlessStatusBar: class { 
   setDiscoveredItems = vi.fn(); 

--- a/src/__tests__/worktree-discovery.test.ts
+++ b/src/__tests__/worktree-discovery.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ---------------------------------------------------------------------------
+// parsePorcelainOutput (pure function — no mocks needed)
+// ---------------------------------------------------------------------------
+
+import { parsePorcelainOutput, resolveGitDir, isGitRepo } from '../worktree-discovery';
+
+describe('parsePorcelainOutput', () => {
+  it('parses a single main worktree', () => {
+    const output = [
+      'worktree /home/user/repo',
+      'HEAD abc1234567890',
+      'branch refs/heads/main',
+      '',
+    ].join('\n');
+
+    const result = parsePorcelainOutput(output);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      path: '/home/user/repo',
+      branch: 'main',
+      isMain: true,
+      commitHash: 'abc1234567890',
+    });
+  });
+
+  it('parses multiple worktrees', () => {
+    const output = [
+      'worktree /home/user/repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /home/user/repo-wt/feat-auth',
+      'HEAD def456',
+      'branch refs/heads/feat/auth',
+      '',
+      'worktree /home/user/repo-wt/bugfix',
+      'HEAD ghi789',
+      'branch refs/heads/bugfix/login',
+      '',
+    ].join('\n');
+
+    const result = parsePorcelainOutput(output);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ path: '/home/user/repo', branch: 'main', isMain: true });
+    expect(result[1]).toMatchObject({ path: '/home/user/repo-wt/feat-auth', branch: 'feat/auth', isMain: false });
+    expect(result[2]).toMatchObject({ path: '/home/user/repo-wt/bugfix', branch: 'bugfix/login', isMain: false });
+  });
+
+  it('parses detached HEAD worktree', () => {
+    const output = [
+      'worktree /home/user/repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /home/user/repo-wt/detached',
+      'HEAD def456',
+      'detached',
+      '',
+    ].join('\n');
+
+    const result = parsePorcelainOutput(output);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      path: '/home/user/repo-wt/detached',
+      branch: '',
+      isMain: false,
+      commitHash: 'def456',
+    });
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parsePorcelainOutput('')).toEqual([]);
+  });
+
+  it('handles Windows-style CRLF line endings', () => {
+    const output = 'worktree C:\\Users\\user\\repo\r\nHEAD abc123\r\nbranch refs/heads/main\r\n\r\n';
+
+    const result = parsePorcelainOutput(output);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('C:\\Users\\user\\repo');
+    expect(result[0].branch).toBe('main');
+  });
+
+  it('skips blocks without worktree line', () => {
+    const output = 'HEAD abc123\nbranch refs/heads/main\n\n';
+
+    const result = parsePorcelainOutput(output);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverWorktrees (mocked execFileSync)
+// ---------------------------------------------------------------------------
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+import { discoverWorktrees } from '../worktree-discovery';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+describe('discoverWorktrees', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns worktrees from git output', () => {
+    mockExecFileSync.mockReturnValue([
+      'worktree /repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo-wt/feat',
+      'HEAD def456',
+      'branch refs/heads/feat/x',
+      '',
+    ].join('\n'));
+
+    const result = discoverWorktrees('/repo');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isMain).toBe(true);
+    expect(result[1].branch).toBe('feat/x');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git', ['worktree', 'list', '--porcelain'],
+      expect.objectContaining({ cwd: '/repo' }),
+    );
+  });
+
+  it('returns empty array when git command fails', () => {
+    mockExecFileSync.mockImplementation(() => { throw new Error('not a git repo'); });
+
+    const result = discoverWorktrees('/not-a-repo');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for non-git directory', () => {
+    mockExecFileSync.mockImplementation(() => { throw new Error('fatal'); });
+    expect(discoverWorktrees('/tmp/empty')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGitDir and isGitRepo (filesystem tests)
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function makeTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-discovery-test-'));
+}
+
+describe('resolveGitDir', () => {
+  beforeEach(() => { tmpDir = makeTmp(); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('returns .git directory path when .git is a directory', () => {
+    const dotGit = path.join(tmpDir, '.git');
+    fs.mkdirSync(dotGit);
+
+    const result = resolveGitDir(tmpDir);
+    expect(result).toBe(dotGit);
+  });
+
+  it('returns resolved gitdir when .git is a file (worktree)', () => {
+    const gitdir = path.join(tmpDir, 'actual-gitdir');
+    fs.mkdirSync(gitdir);
+    fs.writeFileSync(path.join(tmpDir, '.git'), `gitdir: ${gitdir}\n`, 'utf-8');
+
+    const result = resolveGitDir(tmpDir);
+    expect(result).toBe(gitdir);
+  });
+
+  it('resolves relative gitdir path', () => {
+    const innerDir = path.join(tmpDir, 'inner');
+    fs.mkdirSync(innerDir);
+    const relTarget = path.join('..', 'main-repo', '.git', 'worktrees', 'inner');
+    const absTarget = path.resolve(innerDir, relTarget);
+    fs.mkdirSync(absTarget, { recursive: true });
+    fs.writeFileSync(path.join(innerDir, '.git'), `gitdir: ${relTarget}\n`, 'utf-8');
+
+    const result = resolveGitDir(innerDir);
+    expect(result).toBe(absTarget);
+  });
+
+  it('returns undefined when no .git exists', () => {
+    expect(resolveGitDir(tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined for malformed .git file', () => {
+    fs.writeFileSync(path.join(tmpDir, '.git'), 'not-a-gitdir-line\n', 'utf-8');
+    expect(resolveGitDir(tmpDir)).toBeUndefined();
+  });
+});
+
+describe('isGitRepo', () => {
+  beforeEach(() => { tmpDir = makeTmp(); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('returns true when .git directory exists', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    expect(isGitRepo(tmpDir)).toBe(true);
+  });
+
+  it('returns true when .git file exists (worktree)', () => {
+    const gitdir = path.join(tmpDir, 'gitdir');
+    fs.mkdirSync(gitdir);
+    fs.writeFileSync(path.join(tmpDir, '.git'), `gitdir: ${gitdir}\n`);
+    expect(isGitRepo(tmpDir)).toBe(true);
+  });
+
+  it('returns false when no .git exists', () => {
+    expect(isGitRepo(tmpDir)).toBe(false);
+  });
+});

--- a/src/agent-settings.ts
+++ b/src/agent-settings.ts
@@ -58,6 +58,15 @@ export class AgentSettingsManager implements vscode.Disposable {
   }
 
   get(id: string): AgentSettings | undefined {
+    // Worktree child: inherit from parent, merge with worktree-specific overrides
+    const wtIdx = id.indexOf(':wt:');
+    if (wtIdx !== -1) {
+      const parentId = id.slice(0, wtIdx);
+      const parentSettings = this._cache.agents[parentId];
+      const wtSettings = this._cache.agents[id];
+      if (!parentSettings && !wtSettings) return undefined;
+      return { ...parentSettings, ...wtSettings };
+    }
     return this._cache.agents[id];
   }
 
@@ -77,7 +86,14 @@ export class AgentSettingsManager implements vscode.Disposable {
   }
 
   isHidden(id: string): boolean {
-    return this._cache.agents[id]?.hidden === true;
+    if (this._cache.agents[id]?.hidden === true) return true;
+    // Cascading: if parent is hidden, worktree child is also hidden
+    const wtIdx = id.indexOf(':wt:');
+    if (wtIdx !== -1) {
+      const parentId = id.slice(0, wtIdx);
+      return this._cache.agents[parentId]?.hidden === true;
+    }
+    return false;
   }
 
   hide(id: string): void {

--- a/src/editless-tree.ts
+++ b/src/editless-tree.ts
@@ -178,8 +178,10 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
     items.push(this.buildDefaultAgentItem());
 
     // Visible agents at top level, hidden agents in collapsible group
-    const visible = this.stateManager.getDiscoveredItems().filter(i => !this.agentSettings.isHidden(i.id));
-    const hidden = this.stateManager.getDiscoveredItems().filter(i => this.agentSettings.isHidden(i.id));
+    // Filter out worktree children (they appear under their parent)
+    const rootItems = this.stateManager.getDiscoveredItems().filter(i => !i.parentId);
+    const visible = rootItems.filter(i => !this.agentSettings.isHidden(i.id));
+    const hidden = rootItems.filter(i => this.agentSettings.isHidden(i.id));
 
     for (const disc of visible) {
       items.push(this.buildDiscoveredRootItem(disc, false));
@@ -457,6 +459,30 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
       children.push(rosterItem);
     }
 
+    // Worktree children
+    const worktreeChildren = this.stateManager.getDiscoveredItems().filter(i => i.parentId === squadId);
+    for (const wt of worktreeChildren) {
+      const label = wt.branch || wt.name;
+      const wtTerminalCount = this.terminalManager
+        ? this.terminalManager.getTerminalsForSquad(wt.id).length
+        : 0;
+      const wtItem = new EditlessTreeItem(
+        label,
+        'squad',
+        wtTerminalCount > 0
+          ? vscode.TreeItemCollapsibleState.Collapsed
+          : vscode.TreeItemCollapsibleState.None,
+        wt.id,
+      );
+      wtItem.iconPath = new vscode.ThemeIcon('git-branch');
+      wtItem.contextValue = 'worktree';
+      wtItem.description = wt.path;
+      wtItem.tooltip = new vscode.MarkdownString(
+        [`**${label}**`, `Path: \`${wt.path}\``].join('\n\n'),
+      );
+      children.push(wtItem);
+    }
+
     if (parentItem) {
       for (const child of children) {
         child.parent = parentItem;
@@ -469,7 +495,7 @@ export class EditlessTreeProvider implements vscode.TreeDataProvider<EditlessTre
   // -- Hidden group children ------------------------------------------------
 
   private getHiddenGroupChildren(parentItem: EditlessTreeItem): EditlessTreeItem[] {
-    const hidden = this.stateManager.getDiscoveredItems().filter(i => this.agentSettings.isHidden(i.id));
+    const hidden = this.stateManager.getDiscoveredItems().filter(i => !i.parentId && this.agentSettings.isHidden(i.id));
     const children = hidden.map(disc => this.buildDiscoveredRootItem(disc, true));
     for (const child of children) {
       child.parent = parentItem;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { TerminalManager, EDITLESS_INSTRUCTIONS_DIR } from './terminal-manager';
 import { SessionLabelManager } from './session-labels';
 
 
-import { discoverAll, type DiscoveredItem } from './unified-discovery';
+import { discoverAll, enrichWithWorktrees, type DiscoveredItem } from './unified-discovery';
 import type { AgentTeamConfig } from './types';
 import { SquadWatcher } from './watcher';
 import { EditlessStatusBar } from './status-bar';
@@ -253,13 +253,17 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
   );
 
   // --- Unified discovery — agents + squads in one pass (#317, #318) ----------
-  let discoveredItems = discoverAll(vscode.workspace.workspaceFolders ?? []);
+  const wsFolders = vscode.workspace.workspaceFolders ?? [];
+  const includeOutsideWs = vscode.workspace.getConfiguration('editless').get<boolean>('discovery.worktreesOutsideWorkspace', false);
+  let discoveredItems = enrichWithWorktrees(discoverAll(wsFolders), wsFolders, includeOutsideWs);
   treeProvider.setDiscoveredItems(discoveredItems);
   hydrateSettings(discoveredItems, agentSettings);
 
   /** Re-run unified discovery and update tree. */
   function refreshDiscovery(): void {
-    discoveredItems = discoverAll(vscode.workspace.workspaceFolders ?? []);
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    const outsideWs = vscode.workspace.getConfiguration('editless').get<boolean>('discovery.worktreesOutsideWorkspace', false);
+    discoveredItems = enrichWithWorktrees(discoverAll(folders), folders, outsideWs);
     treeProvider.setDiscoveredItems(discoveredItems);
     statusBar.setDiscoveredItems(discoveredItems);
     hydrateSettings(discoveredItems, agentSettings);
@@ -336,6 +340,16 @@ export function activate(context: vscode.ExtensionContext): { terminalManager: T
       });
       context.subscriptions.push(teamMdWatcher);
     }
+  }
+
+  // --- Worktree directory watcher — detect new/removed worktrees -----------
+  for (const folder of (vscode.workspace.workspaceFolders ?? [])) {
+    const wtPattern = new vscode.RelativePattern(folder, '.git/worktrees/*');
+    const wtWatcher = vscode.workspace.createFileSystemWatcher(wtPattern);
+    const onWtChange = (): void => { debouncedRefreshDiscovery(); };
+    wtWatcher.onDidCreate(onWtChange);
+    wtWatcher.onDidDelete(onWtChange);
+    context.subscriptions.push(wtWatcher);
   }
 
   // --- Settings file watcher for cross-window sync -------------------------

--- a/src/worktree-discovery.ts
+++ b/src/worktree-discovery.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface WorktreeInfo {
+  /** Absolute path to the worktree directory. */
+  path: string;
+  /** Branch name (e.g. "feat/auth"), empty string for detached HEAD. */
+  branch: string;
+  /** True for the primary checkout. */
+  isMain: boolean;
+  /** Full commit hash. */
+  commitHash: string;
+}
+
+/**
+ * Run `git worktree list --porcelain` for the given repo path.
+ * Returns structured WorktreeInfo[] parsed from porcelain output.
+ */
+export function discoverWorktrees(repoPath: string): WorktreeInfo[] {
+  let stdout: string;
+  try {
+    stdout = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+  } catch {
+    return [];
+  }
+
+  return parsePorcelainOutput(stdout);
+}
+
+/**
+ * Parse the porcelain output of `git worktree list --porcelain`.
+ * Each entry is separated by a blank line. Format per entry:
+ *   worktree /path/to/worktree
+ *   HEAD abc123...
+ *   branch refs/heads/main
+ *   (or "detached" instead of "branch ...")
+ * The first entry is always the main worktree.
+ */
+export function parsePorcelainOutput(stdout: string): WorktreeInfo[] {
+  const results: WorktreeInfo[] = [];
+  // Split on blank lines (handle both \n\n and \r\n\r\n)
+  const blocks = stdout.split(/\n\s*\n/).filter(b => b.trim());
+
+  for (let i = 0; i < blocks.length; i++) {
+    const lines = blocks[i].split(/\r?\n/);
+    let wtPath = '';
+    let commitHash = '';
+    let branch = '';
+    let isDetached = false;
+
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) {
+        wtPath = line.slice('worktree '.length).trim();
+      } else if (line.startsWith('HEAD ')) {
+        commitHash = line.slice('HEAD '.length).trim();
+      } else if (line.startsWith('branch ')) {
+        const ref = line.slice('branch '.length).trim();
+        // Strip refs/heads/ prefix
+        branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+      } else if (line.trim() === 'detached') {
+        isDetached = true;
+      }
+    }
+
+    if (!wtPath) continue;
+
+    if (isDetached) {
+      branch = '';
+    }
+
+    results.push({
+      path: wtPath,
+      branch,
+      isMain: i === 0,
+      commitHash,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Resolve a directory's .git file/dir to the actual git directory path.
+ * - If .git is a directory: return it directly
+ * - If .git is a file (worktree): read it, parse "gitdir: ..." line, resolve to absolute
+ * - If neither: return undefined (not a git repo)
+ */
+export function resolveGitDir(dirPath: string): string | undefined {
+  const dotGit = path.join(dirPath, '.git');
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(dotGit);
+  } catch {
+    return undefined;
+  }
+
+  if (stat.isDirectory()) {
+    return dotGit;
+  }
+
+  if (stat.isFile()) {
+    try {
+      const content = fs.readFileSync(dotGit, 'utf-8').trim();
+      const match = content.match(/^gitdir:\s*(.+)$/m);
+      if (match) {
+        const gitdir = match[1].trim();
+        return path.isAbsolute(gitdir) ? gitdir : path.resolve(dirPath, gitdir);
+      }
+    } catch {
+      // Unreadable file
+    }
+  }
+
+  return undefined;
+}
+
+/** Quick check if a directory is a git repo (has .git file or directory). */
+export function isGitRepo(dirPath: string): boolean {
+  return resolveGitDir(dirPath) !== undefined;
+}


### PR DESCRIPTION
## Summary

Closes #442

The largest feature in the V0.2 milestone — first-class git worktree support in the EditLess discovery pipeline.

### New Feature

When a user has git worktrees for a repo containing agents/squads, EditLess automatically discovers them and displays them as children of the parent agent in the tree view.

### Changes

- **New: worktree-discovery.ts** — Core module with `discoverWorktrees()`, `resolveGitDir()`, `isGitRepo()` using `git worktree list --porcelain`
- **unified-discovery.ts** — Extended `DiscoveredItem` with `branch?`, `parentId?`, `isMainWorktree?`; new `enrichWithWorktrees()` function with worktree-aware dedup and workspace filtering
- **editless-tree.ts** — Filtered `parentId` items from root; added worktree children rendering with `git-branch` icon and `worktree` contextValue
- **agent-settings.ts** — Settings inheritance via `:wt:` convention; `isHidden()` cascading from parent
- **extension.ts** — Calls `enrichWithWorktrees()` after `discoverAll()`; reads `editless.discovery.worktreesOutsideWorkspace` setting; watches `.git/worktrees/*`
- **package.json** — New `editless.discovery.worktreesOutsideWorkspace` boolean setting

### Architecture

```discoverAll() → flat DiscoveredItem[] → enrichWithWorktrees() → items with worktree children → tree renders parent-child hierarchy```  

### Tests
- 32 new tests covering parsing, discovery, enrichment, dedup, settings inheritance
- 994 total tests passing (962 baseline + 32 new)