### PR TITLE
fix: expand shell variables and strip quotes in parseConfigDir

### DIFF
--- a/src/__tests__/copilot-cli-builder.test.ts
+++ b/src/__tests__/copilot-cli-builder.test.ts
@@ -16,7 +16,7 @@ vi.mock('vscode', () => ({
   },
 }));
 
-import { buildCopilotCommand, buildDefaultLaunchCommand, buildLaunchCommandForConfig, getCliCommand } from '../copilot-cli-builder';
+import { buildCopilotCommand, buildDefaultLaunchCommand, buildLaunchCommandForConfig, getCliCommand, parseConfigDir } from '../copilot-cli-builder';
 import type { CopilotCommandOptions } from '../copilot-cli-builder';
 
 // ---------------------------------------------------------------------------
@@ -452,6 +452,69 @@ describe('copilot-cli-builder', () => {
   describe('legacy config stripping', () => {
     it('getCliCommand returns "copilot" when no override and default setting', () => {
       expect(getCliCommand()).toBe('copilot');
+    });
+  });
+
+  describe('parseConfigDir', () => {
+    it('returns undefined when no additionalArgs', () => {
+      expect(parseConfigDir(undefined)).toBeUndefined();
+      expect(parseConfigDir('')).toBeUndefined();
+    });
+
+    it('parses --config-dir with space-separated path', () => {
+      const result = parseConfigDir('--config-dir /custom/config');
+      expect(result).toContain('custom');
+      expect(result).toContain('config');
+    });
+
+    it('parses --config-dir=path format', () => {
+      const result = parseConfigDir('--config-dir=/custom/config');
+      expect(result).toContain('custom');
+      expect(result).toContain('config');
+    });
+
+    it('strips surrounding quotes from path', () => {
+      const result = parseConfigDir('--config-dir "/custom/config"');
+      expect(result).toContain('custom');
+      expect(result).not.toContain('"');
+    });
+
+    it('expands $env:USERPROFILE in quoted path', () => {
+      const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+      const result = parseConfigDir('--config-dir "$env:USERPROFILE\\copilot-personal"');
+      expect(result).toBeDefined();
+      expect(result).toContain('copilot-personal');
+      expect(result).not.toContain('$env:');
+      expect(result).toContain(home);
+    });
+
+    it('expands %USERPROFILE% in path', () => {
+      const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+      const result = parseConfigDir('--config-dir=%USERPROFILE%\\copilot-personal');
+      expect(result).toBeDefined();
+      expect(result).toContain('copilot-personal');
+      expect(result).not.toContain('%');
+      expect(result).toContain(home);
+    });
+
+    it('expands $env: with --config-dir= format', () => {
+      const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+      const result = parseConfigDir('--config-dir="$env:USERPROFILE\\copilot-personal"');
+      expect(result).toBeDefined();
+      expect(result).toContain('copilot-personal');
+      expect(result).not.toContain('$env:');
+      expect(result).toContain(home);
+    });
+
+    it('handles tilde path', () => {
+      const result = parseConfigDir('--config-dir ~/copilot-personal');
+      expect(result).toBeDefined();
+      expect(result).toContain('copilot-personal');
+      expect(result).not.toContain('~');
+    });
+
+    it('returns undefined when --config-dir is not present', () => {
+      expect(parseConfigDir('--model gpt-5 --yolo')).toBeUndefined();
     });
   });
 });

--- a/src/copilot-cli-builder.ts
+++ b/src/copilot-cli-builder.ts
@@ -161,19 +161,24 @@ export function parseConfigDir(additionalArgs: string | undefined): string | und
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
     if (token === '--config-dir' && i + 1 < tokens.length) {
-      const raw = tokens[i + 1];
-      if (raw.startsWith('~')) {
-        return path.resolve(os.homedir(), raw.slice(2));
-      }
-      return path.resolve(raw);
+      return resolveShellPath(tokens[i + 1]);
     }
     if (token.startsWith('--config-dir=')) {
-      const raw = token.slice('--config-dir='.length);
-      if (raw.startsWith('~')) {
-        return path.resolve(os.homedir(), raw.slice(2));
-      }
-      return path.resolve(raw);
+      return resolveShellPath(token.slice('--config-dir='.length));
     }
   }
   return undefined;
+}
+
+/** Strip quotes and expand shell variables ($env:VAR, %VAR%, ~) before resolving. */
+function resolveShellPath(raw: string): string {
+  let p = raw.replace(/^["']|["']$/g, '');
+  // PowerShell $env:VAR
+  p = p.replace(/\$env:(\w+)/gi, (_, name) => process.env[name] ?? '');
+  // cmd %VAR%
+  p = p.replace(/%(\w+)%/g, (_, name) => process.env[name] ?? '');
+  if (p.startsWith('~')) {
+    return path.resolve(os.homedir(), p.slice(2));
+  }
+  return path.resolve(p);
 }


### PR DESCRIPTION
## Problem

`parseConfigDir` passed raw shell expressions directly to `path.resolve()`, producing incorrect paths like `C:\...\Microsoft VS Code\"`$`env:USERPROFILE\copilot-personal"`.

This caused `isSessionResumable()` to register the wrong config directory, so sessions in custom config dirs could never be resumed.

## Root Cause

When additionalArgs contains `--config-dir "`$`env:USERPROFILE\copilot-personal"`, the PowerShell variable and quotes are meant for the terminal shell. But `parseConfigDir` extracted the raw token and passed it to `path.resolve()`, resolving relative to VS Code's install directory.

## Fix

Added `resolveShellPath()` helper that strips surrounding quotes, expands `$`env:VAR` (PowerShell) and `%VAR%` (cmd) via `process.env`, and preserves existing tilde expansion.

## Tests

Added 7 new test cases covering quoted paths, env var expansion, and format variants.