### PR TITLE
fix: set EDITLESS_WORK_ITEM_URI for local tasks

### DIFF
--- a/src/__tests__/ado-client.test.ts
+++ b/src/__tests__/ado-client.test.ts
@@ -308,7 +308,7 @@ describe('fetchAdoPRs', () => {
     const result = await fetchAdoPRs('myorg', 'myproject', 'test-pat');
     expect(result).toHaveLength(1);
     // Verify votes are stored with lowercase keys
-    expect(result[0]!.reviewerVotes.get('alice@company.com')).toBe(10);
-    expect(result[0]!.reviewerVotes.get('bob@company.com')).toBe(-5);
+    expect(result[0]!.reviewerVotes!.get('alice@company.com')).toBe(10);
+    expect(result[0]!.reviewerVotes!.get('bob@company.com')).toBe(-5);
   });
 });


### PR DESCRIPTION
Local tasks have a filePath but no url, so the env variable was never populated when launching a session from a local task. Now falls back to filePath when no url is available. Also updated the custom instructions to tell the agent to read local file paths directly.