### PR TITLE
fix: include project name in ADO work item details URL

### DIFF
--- a/src/__tests__/ado-client.test.ts
+++ b/src/__tests__/ado-client.test.ts
@@ -198,6 +198,46 @@ describe('fetchAdoWorkItems', () => {
     const totalIds = idsRequested.join(',').split(',').length;
     expect(totalIds).toBeLessThanOrEqual(200);
   });
+  it('should include project name in work item details URL', async () => {
+    // Setup a successful WIQL response with one ID
+    setupRequestResponse(200, JSON.stringify({ workItems: [{ id: 1 }] }));
+
+    let capturedDetailsPath = '';
+    mockHttpsGet.mockImplementation((opts: { path?: string }, cb: Function) => {
+      capturedDetailsPath = (opts as any).path || '';
+      const body = JSON.stringify({ value: [{
+        id: 1,
+        fields: {
+          'System.Title': 'Test',
+          'System.State': 'Active',
+          'System.WorkItemType': 'Bug',
+          'System.AssignedTo': { displayName: 'Dev' },
+          'System.AreaPath': 'Proj',
+          'System.Tags': '',
+        },
+        _links: { html: { href: 'https://example.com' } },
+      }] });
+      const resListeners = new Map<string, Function>();
+      const res = {
+        statusCode: 200,
+        on: (event: string, handler: Function) => { resListeners.set(event, handler); return res; },
+      };
+      Promise.resolve().then(() => {
+        cb(res);
+        resListeners.get('data')?.(Buffer.from(body));
+        resListeners.get('end')?.();
+      });
+      const req = {
+        on: (event: string, handler: Function) => { return req; },
+        destroy: vi.fn(),
+      };
+      return req;
+    });
+
+    await fetchAdoWorkItems('https://dev.azure.com/myorg', 'MyProject', 'test-pat');
+    // The details URL must include the project name between org and _apis
+    expect(capturedDetailsPath).toContain('/MyProject/_apis/wit/workitems');
+  });
 });
 
 describe('fetchAdoPRs', () => {

--- a/src/ado-client.ts
+++ b/src/ado-client.ts
@@ -154,7 +154,7 @@ export async function fetchAdoWorkItems(
   
   for (let i = 0; i < ids.length && i < limit; i += batchSize) {
     const batchIds = ids.slice(i, Math.min(i + batchSize, limit));
-    const detailsUrl = `https://dev.azure.com/${orgName}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.Id,System.Title,System.State,System.WorkItemType,System.AssignedTo,System.AreaPath,System.Tags,System.Parent&api-version=7.1`;
+    const detailsUrl = `https://dev.azure.com/${orgName}/${encodeURIComponent(project)}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.Id,System.Title,System.State,System.WorkItemType,System.AssignedTo,System.AreaPath,System.Tags,System.Parent&api-version=7.1`;
 
     interface WorkItemDetail {
       id: number;


### PR DESCRIPTION
Closes #517

The work item details fetch endpoint was missing the project name in the URL path, causing API calls to fail silently and return no work items.

The WIQL query URL and all PR endpoints correctly included the project (e.g. `/orgName/project/_apis/...`), but the batch details URL used `/orgName/_apis/wit/workitems` which ADO rejects without project context.

### Changes
- `src/ado-client.ts`: Added `/\$\{encodeURIComponent(project)\}` to the details URL on line 157
- `src/__tests__/ado-client.test.ts`: Added regression test verifying project is in the details URL path

All 11 ADO client tests pass.