### PR TITLE
Fix COPILOT_CUSTOM_INSTRUCTIONS_DIRS handling

### DIFF
--- a/src/__tests__/terminal-manager.test.ts
+++ b/src/__tests__/terminal-manager.test.ts
@@ -83,7 +83,7 @@ vi.mock('vscode', () => ({
   },
 }));
 
-import { TerminalManager, type PersistedTerminalInfo, type SessionState, stripEmoji, resolveTerminalCwd } from '../terminal-manager';
+import { buildEditlessCustomInstructionsDirs, EDITLESS_INSTRUCTIONS_DIR, TerminalManager, type PersistedTerminalInfo, type SessionState, stripEmoji, resolveTerminalCwd } from '../terminal-manager';
 import * as vscodeModule from 'vscode';
 
 function makeMockTerminal(name: string): vscode.Terminal {
@@ -151,6 +151,10 @@ function getLastPersistedState(ctx: vscode.ExtensionContext): PersistedTerminalI
   const persistCalls = calls.filter(c => c[0] === 'editless.terminalSessions');
   const lastCall = persistCalls.at(-1);
   return lastCall ? lastCall[1] as PersistedTerminalInfo[] : undefined;
+}
+
+function getLastCreateTerminalOptions(): vscode.TerminalOptions {
+  return mockCreateTerminal.mock.calls.at(-1)?.[0] as vscode.TerminalOptions;
 }
 
 let capturedCloseListener: CloseListener;
@@ -2129,29 +2133,42 @@ describe('TerminalManager', () => {
     });
 
     it('should pass EDITLESS env vars via TerminalOptions.env', () => {
+      const previousCustomInstructionsDirs = process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+      process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = '/custom/one,/custom/two';
+
       const orphanEntry = makePersistedEntry({
         id: 'resume-env-1',
         terminalName: '🧪 No Match',
         launchCommand: 'copilot --agent squad',
         agentSessionId: 'env-session',
       });
-      const ctx = makeMockContext([orphanEntry]);
-      const mgr = new TerminalManager(ctx);
-      mgr.reconcile();
 
-      mgr.relaunchSession(orphanEntry);
+      try {
+        const ctx = makeMockContext([orphanEntry]);
+        const mgr = new TerminalManager(ctx);
+        mgr.reconcile();
 
-      expect(mockCreateTerminal).toHaveBeenCalledWith(
-        expect.objectContaining({
-          env: expect.objectContaining({
-            EDITLESS_SESSION_ID: 'resume-env-1',
-            EDITLESS_AGENT_SESSION_ID: 'env-session',
-            EDITLESS_TERMINAL_ID: 'resume-env-1',
-            EDITLESS_SQUAD_ID: 'test-squad',
-            EDITLESS_SQUAD_NAME: 'Test Squad',
+        mgr.relaunchSession(orphanEntry);
+
+        expect(mockCreateTerminal).toHaveBeenCalledWith(
+          expect.objectContaining({
+            env: expect.objectContaining({
+              EDITLESS_SESSION_ID: 'resume-env-1',
+              EDITLESS_AGENT_SESSION_ID: 'env-session',
+              COPILOT_CUSTOM_INSTRUCTIONS_DIRS: `/custom/one,/custom/two,${EDITLESS_INSTRUCTIONS_DIR}`,
+              EDITLESS_TERMINAL_ID: 'resume-env-1',
+              EDITLESS_SQUAD_ID: 'test-squad',
+              EDITLESS_SQUAD_NAME: 'Test Squad',
+            }),
           }),
-        }),
-      );
+        );
+      } finally {
+        if (previousCustomInstructionsDirs === undefined) {
+          delete process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+        } else {
+          process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = previousCustomInstructionsDirs;
+        }
+      }
     });
 
     it('should still pass terminal/squad env vars when no agentSessionId', () => {
@@ -2204,6 +2221,18 @@ describe('TerminalManager', () => {
   // Phase 2: Terminal integration with --resume UUID
   // -------------------------------------------------------------------------
 
+  describe('buildEditlessCustomInstructionsDirs', () => {
+    it('should append the Editless instructions dir using commas', () => {
+      expect(buildEditlessCustomInstructionsDirs('/custom/one,/custom/two')).toBe(
+        `/custom/one,/custom/two,${EDITLESS_INSTRUCTIONS_DIR}`,
+      );
+      expect(buildEditlessCustomInstructionsDirs('/custom/one;/custom/two')).toBe(
+        `/custom/one,/custom/two,${EDITLESS_INSTRUCTIONS_DIR}`,
+      );
+      expect(buildEditlessCustomInstructionsDirs(undefined)).toBe(EDITLESS_INSTRUCTIONS_DIR);
+    });
+  });
+
   describe('launchTerminal with --resume UUID', () => {
     it('should set agentSessionId immediately on launch', () => {
       const mockUuid = 'test-uuid-12345';
@@ -2254,6 +2283,30 @@ describe('TerminalManager', () => {
       const createOpts = mockCreateTerminal.mock.calls[0][0] as vscode.TerminalOptions;
       expect(createOpts.env?.EDITLESS_SQUAD_ID).toBe('my-squad');
       expect(createOpts.env?.EDITLESS_SQUAD_NAME).toBe('My Squad');
+    });
+
+    it('should preserve comma-separated COPILOT_CUSTOM_INSTRUCTIONS_DIRS when launching', () => {
+      const previousCustomInstructionsDirs = process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+      process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = '/custom/one,/custom/two';
+
+      try {
+        const ctx = makeMockContext();
+        const mgr = new TerminalManager(ctx);
+        const config = makeSquadConfig();
+
+        mgr.launchTerminal(config);
+
+        const createOpts = getLastCreateTerminalOptions();
+        expect(createOpts.env?.COPILOT_CUSTOM_INSTRUCTIONS_DIRS).toBe(
+          `/custom/one,/custom/two,${EDITLESS_INSTRUCTIONS_DIR}`,
+        );
+      } finally {
+        if (previousCustomInstructionsDirs === undefined) {
+          delete process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+        } else {
+          process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = previousCustomInstructionsDirs;
+        }
+      }
     });
 
     it('should set isTransient: true on created terminal', () => {

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -4,7 +4,7 @@ import type { TerminalInfo, PersistedTerminalInfo } from './terminal-types';
 import type { SessionContextResolver, SessionEvent } from './session-context';
 import { resolveTerminalCwd } from './cwd-resolver';
 import { resolveShellPath } from './copilot-cli-builder';
-import { EDITLESS_INSTRUCTIONS_DIR } from './terminal-manager';
+import { buildEditlessCustomInstructionsDirs } from './terminal-manager';
 
 export interface SessionRecoveryContext {
   terminals: Map<vscode.Terminal, TerminalInfo>;
@@ -124,7 +124,9 @@ export class SessionRecovery {
       iconPath: new vscode.ThemeIcon('terminal'),
       env: {
         ...env,
-        COPILOT_CUSTOM_INSTRUCTIONS_DIRS: [process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS, EDITLESS_INSTRUCTIONS_DIR].filter(Boolean).join(path.delimiter),
+        COPILOT_CUSTOM_INSTRUCTIONS_DIRS: buildEditlessCustomInstructionsDirs(
+          process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS,
+        ),
         EDITLESS_TERMINAL_ID: entry.id,
         EDITLESS_SQUAD_ID: entry.agentId,
         EDITLESS_SQUAD_NAME: entry.agentName,

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -16,6 +16,16 @@ import type { TerminalInfo, PersistedTerminalInfo } from './terminal-types';
 
 export const EDITLESS_INSTRUCTIONS_DIR = path.join(os.homedir(), '.copilot', 'editless');
 
+function joinCopilotCustomInstructionsDirs(...dirs: Array<string | undefined>): string {
+  return dirs.filter((dir): dir is string => Boolean(dir)).join(',');
+}
+
+// Copilot CLI expects this env var to be a comma-separated list of directories.
+export function buildEditlessCustomInstructionsDirs(existingDirs: string | undefined): string {
+  const normalizedExistingDirs = existingDirs?.replace(/;/g, ',');
+  return joinCopilotCustomInstructionsDirs(normalizedExistingDirs, EDITLESS_INSTRUCTIONS_DIR);
+}
+
 // Re-exports for backward compatibility
 export type { SessionState } from './terminal-state';
 export { getStateIcon, getStateDescription } from './terminal-state';
@@ -150,7 +160,9 @@ export class TerminalManager implements vscode.Disposable {
       iconPath: new vscode.ThemeIcon('terminal'),
       env: {
         ...extraEnv,
-        COPILOT_CUSTOM_INSTRUCTIONS_DIRS: [process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS, EDITLESS_INSTRUCTIONS_DIR].filter(Boolean).join(path.delimiter),
+        COPILOT_CUSTOM_INSTRUCTIONS_DIRS: buildEditlessCustomInstructionsDirs(
+          process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS,
+        ),
         EDITLESS_TERMINAL_ID: id,
         EDITLESS_SQUAD_ID: config.id,
         EDITLESS_SQUAD_NAME: config.name,


### PR DESCRIPTION
Closes #527

EditLess was appending its instructions directory with the OS path delimiter, which produces `;` on Windows even though Copilot CLI expects `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` to be comma-separated. This centralizes that env-var construction so both fresh launches and recovered sessions use the format Copilot CLI expects.

- add `buildEditlessCustomInstructionsDirs()` to encapsulate how EditLess appends its instructions directory
- use the shared helper in both terminal launch and session recovery
- normalize legacy semicolon-separated values from the previous Windows bug for safer upgrades
- add regression coverage for the helper plus launch/relaunch env propagation

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- src/__tests__/terminal-manager.test.ts`