### PR TITLE
Add copy actions to work item and PR menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,18 @@
         "icon": "$(link-external)"
       },
       {
+        "command": "editless.copyDescription",
+        "title": "Copy Description",
+        "category": "EditLess",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "editless.copyUrl",
+        "title": "Copy URL",
+        "category": "EditLess",
+        "icon": "$(link)"
+      },
+      {
         "command": "editless.launchFromWorkItem",
         "title": "Launch with Agent",
         "category": "EditLess",
@@ -547,6 +559,16 @@
           "group": "work-item@1"
         },
         {
+          "command": "editless.copyDescription",
+          "when": "viewItem =~ /^(work-item|ado-work-item|ado-parent-item)$/",
+          "group": "work-item@2"
+        },
+        {
+          "command": "editless.copyUrl",
+          "when": "viewItem =~ /^(work-item|ado-work-item|ado-parent-item)$/",
+          "group": "work-item@3"
+        },
+        {
           "command": "editless.openTaskFile",
           "when": "viewItem == local-task",
           "group": "work-item@2"
@@ -554,7 +576,7 @@
         {
           "command": "editless.openInBrowser",
           "when": "viewItem =~ /^(work-item|ado-work-item|ado-parent-item)$/",
-          "group": "work-item@3"
+          "group": "work-item@4"
         },
         {
           "command": "editless.launchFromPR",
@@ -572,9 +594,19 @@
           "group": "pull-request@1"
         },
         {
-          "command": "editless.openInBrowser",
+          "command": "editless.copyDescription",
           "when": "viewItem =~ /^(pull-request|ado-pull-request)$/",
           "group": "pull-request@2"
+        },
+        {
+          "command": "editless.copyUrl",
+          "when": "viewItem =~ /^(pull-request|ado-pull-request)$/",
+          "group": "pull-request@3"
+        },
+        {
+          "command": "editless.openInBrowser",
+          "when": "viewItem =~ /^(pull-request|ado-pull-request)$/",
+          "group": "pull-request@4"
         },
         {
           "command": "editless.relaunchSession",
@@ -713,6 +745,14 @@
         },
         {
           "command": "editless.openInBrowser",
+          "when": "false"
+        },
+        {
+          "command": "editless.copyDescription",
+          "when": "false"
+        },
+        {
+          "command": "editless.copyUrl",
           "when": "false"
         },
         {

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -1568,21 +1568,21 @@ describe('extension command handlers', () => {
       const item = { issue: { number: 42, title: 'Fix bug' } };
       await getHandler('editless.copyDescription')(item);
       expect(mockClipboardWriteText).toHaveBeenCalledWith('Issue#42: Fix bug');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied Issue#42: Fix bug to clipboard');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied description to clipboard');
     });
 
     it('should copy ADO work item description text with type abbreviation', async () => {
       const item = { adoWorkItem: { id: 1234, title: 'Ship onboarding flow', type: 'User Story' } };
       await getHandler('editless.copyDescription')(item);
       expect(mockClipboardWriteText).toHaveBeenCalledWith('US#1234: Ship onboarding flow');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied US#1234: Ship onboarding flow to clipboard');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied description to clipboard');
     });
 
     it('should copy PR description text', async () => {
       const item = { pr: { number: 100, title: 'Add feature' } };
       await getHandler('editless.copyDescription')(item);
       expect(mockClipboardWriteText).toHaveBeenCalledWith('PR#100: Add feature');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied PR#100: Add feature to clipboard');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied description to clipboard');
     });
 
     it('should no-op when the item has no description text', async () => {
@@ -1599,14 +1599,14 @@ describe('extension command handlers', () => {
       const item = { issue: { url: 'https://github.com/owner/repo/issues/42' } };
       await getHandler('editless.copyUrl')(item);
       expect(mockClipboardWriteText).toHaveBeenCalledWith('https://github.com/owner/repo/issues/42');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied https://github.com/owner/repo/issues/42 to clipboard');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied URL to clipboard');
     });
 
     it('should copy a PR URL', async () => {
       const item = { adoPR: { url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/200' } };
       await getHandler('editless.copyUrl')(item);
       expect(mockClipboardWriteText).toHaveBeenCalledWith('https://dev.azure.com/org/project/_git/repo/pullrequest/200');
-      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied https://dev.azure.com/org/project/_git/repo/pullrequest/200 to clipboard');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied URL to clipboard');
     });
 
     it('should no-op when the item has no URL', async () => {

--- a/src/__tests__/extension-commands.test.ts
+++ b/src/__tests__/extension-commands.test.ts
@@ -71,6 +71,7 @@ const {
   mockOnDidCloseTerminal,
   mockResolveTeamDir,
   mockLaunchAndLabel,
+  mockClipboardWriteText,
 } = vi.hoisted(() => ({
   mockRegisterCommand: vi.fn(),
   mockExecuteCommand: vi.fn(),
@@ -135,10 +136,11 @@ const {
     mockWorkspaceFsCopy: vi.fn(),
     mockDiscoverAll: vi.fn().mockReturnValue([]),
     mockDiscoverAllAsync: vi.fn().mockResolvedValue([]),
-    mockOnDidCloseTerminal: vi.fn(() => ({ dispose: vi.fn() })),
-    mockResolveTeamDir: vi.fn(),
-    mockLaunchAndLabel: vi.fn(),
-  }),
+     mockOnDidCloseTerminal: vi.fn(() => ({ dispose: vi.fn() })),
+     mockResolveTeamDir: vi.fn(),
+     mockLaunchAndLabel: vi.fn(),
+     mockClipboardWriteText: vi.fn(),
+   }),
 );
 
 // Registered command handlers captured during activate()
@@ -217,7 +219,7 @@ vi.mock('vscode', async () => {
     },
     env: {
       openExternal: mockOpenExternal,
-      clipboard: { writeText: vi.fn() },
+      clipboard: { writeText: mockClipboardWriteText },
     },
     extensions: {
       getExtension: vi.fn(),
@@ -1556,6 +1558,61 @@ describe('extension command handlers', () => {
       const item = {};
       await getHandler('editless.openInBrowser')(item);
       expect(mockOpenExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- editless.copyDescription -----------------------------------------------
+
+  describe('editless.copyDescription', () => {
+    it('should copy GitHub issue description text', async () => {
+      const item = { issue: { number: 42, title: 'Fix bug' } };
+      await getHandler('editless.copyDescription')(item);
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('Issue#42: Fix bug');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied Issue#42: Fix bug to clipboard');
+    });
+
+    it('should copy ADO work item description text with type abbreviation', async () => {
+      const item = { adoWorkItem: { id: 1234, title: 'Ship onboarding flow', type: 'User Story' } };
+      await getHandler('editless.copyDescription')(item);
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('US#1234: Ship onboarding flow');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied US#1234: Ship onboarding flow to clipboard');
+    });
+
+    it('should copy PR description text', async () => {
+      const item = { pr: { number: 100, title: 'Add feature' } };
+      await getHandler('editless.copyDescription')(item);
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('PR#100: Add feature');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied PR#100: Add feature to clipboard');
+    });
+
+    it('should no-op when the item has no description text', async () => {
+      await getHandler('editless.copyDescription')({});
+      expect(mockClipboardWriteText).not.toHaveBeenCalled();
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- editless.copyUrl -------------------------------------------------------
+
+  describe('editless.copyUrl', () => {
+    it('should copy a work item URL', async () => {
+      const item = { issue: { url: 'https://github.com/owner/repo/issues/42' } };
+      await getHandler('editless.copyUrl')(item);
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('https://github.com/owner/repo/issues/42');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied https://github.com/owner/repo/issues/42 to clipboard');
+    });
+
+    it('should copy a PR URL', async () => {
+      const item = { adoPR: { url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/200' } };
+      await getHandler('editless.copyUrl')(item);
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('https://dev.azure.com/org/project/_git/repo/pullrequest/200');
+      expect(mockShowInformationMessage).toHaveBeenCalledWith('Copied https://dev.azure.com/org/project/_git/repo/pullrequest/200 to clipboard');
+    });
+
+    it('should no-op when the item has no URL', async () => {
+      await getHandler('editless.copyUrl')({});
+      expect(mockClipboardWriteText).not.toHaveBeenCalled();
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/work-item-commands.ts
+++ b/src/commands/work-item-commands.ts
@@ -254,7 +254,7 @@ export function register(context: vscode.ExtensionContext, deps: WorkItemCommand
       if (!text) return;
 
       await vscode.env.clipboard.writeText(text);
-      vscode.window.showInformationMessage(`Copied ${text} to clipboard`);
+      vscode.window.showInformationMessage('Copied description to clipboard');
     }),
   );
 
@@ -267,7 +267,7 @@ export function register(context: vscode.ExtensionContext, deps: WorkItemCommand
       if (!url) return;
 
       await vscode.env.clipboard.writeText(url);
-      vscode.window.showInformationMessage(`Copied ${url} to clipboard`);
+      vscode.window.showInformationMessage('Copied URL to clipboard');
     }),
   );
 

--- a/src/commands/work-item-commands.ts
+++ b/src/commands/work-item-commands.ts
@@ -10,7 +10,14 @@ import { fetchLinkedPRs } from '../github-client';
 import type { DiscoveredItem } from '../unified-discovery';
 import { promptAdoSignIn } from '../ado-auth';
 import { buildLevelFilterPicker, buildPRLevelFilterPicker } from './level-filter-picker';
-import { launchFromWorkItem, launchFromPR } from './work-item-launcher';
+import {
+  buildPrDescriptionText,
+  buildWorkItemDescriptionText,
+  getPrUrl,
+  getWorkItemUrl,
+  launchFromPR,
+  launchFromWorkItem,
+} from './work-item-launcher';
 
 export interface WorkItemCommandDeps {
   agentSettings: AgentSettingsManager;
@@ -231,10 +238,36 @@ export function register(context: vscode.ExtensionContext, deps: WorkItemCommand
     vscode.commands.registerCommand('editless.openInBrowser', async (arg: WorkItemsTreeItem | PRsTreeItem) => {
       const wiItem = arg as WorkItemsTreeItem;
       const prItem = arg as PRsTreeItem;
-      const url = wiItem.issue?.url ?? wiItem.adoWorkItem?.url ?? prItem.pr?.url ?? prItem.adoPR?.url;
+      const url = getWorkItemUrl(wiItem) ?? getPrUrl(prItem);
       if (url) {
         await vscode.env.openExternal(vscode.Uri.parse(url));
       }
+    }),
+  );
+
+  // Copy item description text (context menu for work items and PRs)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.copyDescription', async (arg: WorkItemsTreeItem | PRsTreeItem) => {
+      const wiItem = arg as WorkItemsTreeItem;
+      const prItem = arg as PRsTreeItem;
+      const text = buildWorkItemDescriptionText(wiItem) ?? buildPrDescriptionText(prItem);
+      if (!text) return;
+
+      await vscode.env.clipboard.writeText(text);
+      vscode.window.showInformationMessage(`Copied ${text} to clipboard`);
+    }),
+  );
+
+  // Copy item URL (context menu for work items and PRs)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('editless.copyUrl', async (arg: WorkItemsTreeItem | PRsTreeItem) => {
+      const wiItem = arg as WorkItemsTreeItem;
+      const prItem = arg as PRsTreeItem;
+      const url = getWorkItemUrl(wiItem) ?? getPrUrl(prItem);
+      if (!url) return;
+
+      await vscode.env.clipboard.writeText(url);
+      vscode.window.showInformationMessage(`Copied ${url} to clipboard`);
     }),
   );
 

--- a/src/commands/work-item-launcher.ts
+++ b/src/commands/work-item-launcher.ts
@@ -76,6 +76,22 @@ function buildPrInitialPrompt(item: PRsTreeItem | undefined): string | undefined
   return formatInitialPrompt('PR', number, title);
 }
 
+export function buildWorkItemDescriptionText(item?: WorkItemsTreeItem): string | undefined {
+  return buildWorkItemInitialPrompt(item);
+}
+
+export function buildPrDescriptionText(item?: PRsTreeItem): string | undefined {
+  return buildPrInitialPrompt(item);
+}
+
+export function getWorkItemUrl(item?: WorkItemsTreeItem): string | undefined {
+  return item?.issue?.url ?? item?.adoWorkItem?.url;
+}
+
+export function getPrUrl(item?: PRsTreeItem): string | undefined {
+  return item?.pr?.url ?? item?.adoPR?.url;
+}
+
 /** Launch a Copilot session from a work item (issue, ADO item, or local task). */
 export async function launchFromWorkItem(deps: LauncherDeps, item?: WorkItemsTreeItem): Promise<void> {
   const issue = item?.issue;
@@ -90,7 +106,7 @@ export async function launchFromWorkItem(deps: LauncherDeps, item?: WorkItemsTre
   const number = issue?.number ?? adoItem?.id;
   const title = issue?.title ?? adoItem?.title ?? localTask?.title ?? '';
   const localPath = localTask?.filePath;
-  const url = issue?.url ?? adoItem?.url ?? (localPath ? vscode.Uri.file(localPath).toString() : '');
+  const url = getWorkItemUrl(item) ?? (localPath ? vscode.Uri.file(localPath).toString() : '');
   const displayLabel = localTask ? localTask.title : `#${number} ${title}`;
 
   const cliItem = {
@@ -145,7 +161,7 @@ export async function launchFromPR(deps: LauncherDeps, item?: PRsTreeItem): Prom
 
   const number = pr?.number ?? adoPR?.id;
   const title = pr?.title ?? adoPR?.title ?? '';
-  const url = pr?.url ?? adoPR?.url ?? '';
+  const url = getPrUrl(item) ?? '';
 
   const cliItem = {
     label: '$(terminal) Copilot CLI',


### PR DESCRIPTION
Closes #540

This adds explicit right-click copy actions for work items and pull requests so users can grab either the item text or the URL without launching a session first.

## What changed

- adds `Copy Description` and `Copy URL` context-menu actions for work items and PRs
- keeps those commands out of the command palette and scoped to the relevant tree items only
- reuses the existing item text formatting so copied descriptions stay consistent with current `Issue#42: Title`, `US#1234: Title`, and `PR#100: Title` patterns
- adds focused command-handler tests covering both new actions and their no-op cases

## Notes

- this keeps the new actions on the right-click menus rather than adding more inline affordances
- local task behavior is unchanged; the new copy commands target work items and PRs with existing external item metadata

## Validation

- `npm run lint`
- `npm run build`
- `npx vitest run src/__tests__/extension-commands.test.ts`
- `npm run test` currently times out in this repo and appears broader than this change